### PR TITLE
[feature] IconButton 컴포넌트 구현

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import colors from '@/constants/colors';
+import { fontSize } from '@/constants/font';
+
+type IconButtonSizeType = 'sm' | 'md';
+type IconButtonColorType = 'primary' | 'gray' | 'red' | 'black';
+
+interface IconProps {
+  size?: string | number;
+  fill?: string;
+}
+
+interface IconButtonProps {
+  IconComponent: React.ComponentType<IconProps>;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  label?: string;
+  size?: IconButtonSizeType;
+  color?: IconButtonColorType;
+  fillColor?: IconButtonColorType;
+}
+
+type IconButtonColors = {
+  color: string;
+};
+
+const iconButtonColors: Record<IconButtonColorType, IconButtonColors> = {
+  primary: { color: colors.primaryNormal },
+  gray: { color: colors.gray05 },
+  red: { color: colors.redNormal },
+  black: { color: colors.black },
+};
+
+const IconButton: React.FC<IconButtonProps> = ({
+  IconComponent,
+  onClick,
+  label = '',
+  size = 'md',
+  color = 'primary',
+  fillColor,
+}) => {
+  const selectColors = iconButtonColors[color].color;
+  const selectFillColor = fillColor
+    ? iconButtonColors[fillColor].color
+    : 'none';
+
+  return (
+    <button css={IconButtonStyle(size, selectColors)} onClick={onClick}>
+      <IconComponent size={size === 'md' ? 24 : 12} fill={selectFillColor} />
+      {label}
+    </button>
+  );
+};
+
+const IconButtonStyle = (size: IconButtonSizeType, selectColors: string) => css`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  border: none;
+  background-color: transparent;
+  gap: 2px;
+  outline: none;
+  font-size: ${size === 'md' ? fontSize.xs : fontSize.xxs};
+  color: ${selectColors};
+
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+export default IconButton;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

IconButton 컴포넌트 구현

## 📋 작업 내용

- IconButton 컴포넌트를 구현했습니다.

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

![Component 1](https://github.com/user-attachments/assets/220855d5-01a4-4cbd-981d-55f232f4e461)

## 📄 기타

Button 컴포넌트와 같은 방식으로 lucide-react 라이브러리를 통해 아이콘을 사용할 수 있도록 했습니다.
