### PR TITLE
[feature] HashTag 컴포넌트 구현

### DIFF
--- a/src/components/HashTag.tsx
+++ b/src/components/HashTag.tsx
@@ -1,0 +1,73 @@
+import { css } from '@emotion/react';
+import colors from '@/constants/colors';
+import { fontSize, fontWeight } from '@/constants/font';
+import useTagSelection from '@/hooks/useTagSelection';
+
+export interface Tag {
+  id: number;
+  label: string;
+  removable: boolean;
+}
+
+interface TagProps {
+  tags: Tag[];
+  onRemove: (id: number) => void;
+}
+
+const HashTag: React.FC<TagProps> = ({ tags, onRemove }) => {
+  const { selectedTags, onTagSelection } = useTagSelection();
+
+  return (
+    <div>
+      {tags.map((tag) => (
+        <div
+          key={tag.id}
+          css={tagStyle(selectedTags.includes(tag.id), tag.removable)}
+          onClick={() => onTagSelection(tag.id, tag.removable)}
+        >
+          {tag.label}
+          {tag.removable && (
+            <button
+              css={removeButtonStyle}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove(tag.id);
+              }}
+            >
+              X
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const tagStyle = (isSelected: boolean, removable: boolean) => css`
+  display: inline-flex;
+  align-items: center;
+  margin-right: 3px;
+  border: 1px solid ${colors.gray02};
+  font-size: ${fontSize.sm};
+  font-weight: ${fontWeight.medium};
+  background-color: ${isSelected ? colors.primaryNormal : `none`};
+  color: ${isSelected ? 'white' : 'black'};
+  border-radius: 50px;
+  padding: 8px 12px;
+  cursor: ${removable ? 'default' : 'pointer'};
+  transition: background-color 0.5s;
+
+  &:hover {
+    background-color: ${isSelected ? colors.primaryNormal : `none`};
+  }
+`;
+
+const removeButtonStyle = css`
+  font-size: ${fontSize.xs};
+  margin-left: 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+`;
+
+export default HashTag;

--- a/src/hooks/useTagSelection.ts
+++ b/src/hooks/useTagSelection.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+const useTagSelection = (initialSelectedTags: number[] = []) => {
+  const [selectedTags, setSelectedTags] =
+    useState<number[]>(initialSelectedTags);
+
+  const onTagSelection = (id: number, removable: boolean) => {
+    if (removable) return;
+    setSelectedTags((prev) =>
+      prev.includes(id) ? prev.filter((tagId) => tagId !== id) : [...prev, id]
+    );
+  };
+
+  return {
+    selectedTags,
+    onTagSelection,
+  };
+};
+
+export default useTagSelection;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

해시태그 컴포넌트 구현

## 📋 작업 내용

- 해시태그 컴포넌트 UI 구현
- removable 속성에 따라 태그 삭제 표시 여부 가능
- removable 속성이 true -> 삭제 가능한 해시태그인 경우 선택 불가 기능
- 태그의 선택 상태를 관리하는 useTagSelection 커스텀 훅 구현

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)
<img width="360" alt="image" src="https://github.com/user-attachments/assets/b33c285e-4e2f-490a-9747-4c1ad9cf5523">

## 📄 기타
테스트 코드
```
const Test: React.FC = () => {
  const [tags, setTags] = useState<Tag[]>([
    { id: 1, label: '#Game', removable: true },
    { id: 2, label: '#Dogs', removable: true },
    { id: 3, label: '#FrontEnd', removable: false },
    { id: 4, label: '#Movie', removable: false },
  ]);

  const removeTag = (id: number) => {
    setTags(tags.filter((tag) => tag.id !== id));
  };

  return (
    <div css={containerStyle}>
      <HashTag tags={tags} onRemove={removeTag} />
    </div>
  );
};
```
