### PR TITLE
[feature] Profile 컴포넌트 구현

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+type ProfileProps = {
+  src: string;
+  alt: string;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+};
+
+const sizes = {
+  xs: 32,
+  sm: 36,
+  md: 48,
+  lg: 100,
+  xl: 120,
+};
+
+const Profile: React.FC<ProfileProps> = ({ src, alt, size = 'lg' }) => (
+  <div
+    css={css`
+      width: ${sizes[size]}px;
+      height: ${sizes[size]}px;
+      border-radius: 50%;
+      overflow: hidden;
+      display: inline-block;
+    `}
+  >
+    <img
+      src={src}
+      alt={alt}
+      css={css`
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      `}
+    />
+  </div>
+);
+
+export default Profile;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

Profile 컴포넌트 구현

## 📋 작업 내용

프로필을 크기별로 사용 가능하게 구현
- xs: header Profile
- sm: 댓글 Profile
- md: 모든 팔로잉 목록 Profile
- lg: 마이플리 페이지 Profile
- xl: 마이페이지

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

<img width="564" alt="image" src="https://github.com/user-attachments/assets/6414d1f2-2d56-4928-a066-273e2f7d094d">


## 📄 기타
```
    <Profile
      src={user.profileImageUrl}
      alt={`${user.name}'s profile`}
      size='xs'
    />
```
