### PR TITLE
[fix] IconButton, TextFilter 컴포넌트 수정

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -17,6 +17,7 @@ interface IconButtonProps {
   label?: string;
   size?: IconButtonSizeType;
   color?: IconButtonColorType;
+  labelColor?: IconButtonColorType;
   fillColor?: IconButtonColorType;
 }
 
@@ -36,10 +37,14 @@ const IconButton: React.FC<IconButtonProps> = ({
   onClick,
   label = '',
   size = 'md',
-  color = 'primary',
+  color = 'gray',
+  labelColor,
   fillColor,
 }) => {
   const selectColors = iconButtonColors[color].color;
+  const selectLabelColor = labelColor
+    ? iconButtonColors[labelColor].color
+    : selectColors;
   const selectFillColor = fillColor
     ? iconButtonColors[fillColor].color
     : 'none';
@@ -47,7 +52,7 @@ const IconButton: React.FC<IconButtonProps> = ({
   return (
     <button css={iconButtonStyle(size, selectColors)} onClick={onClick}>
       <IconComponent size={size === 'md' ? 24 : 12} fill={selectFillColor} />
-      {label}
+      <span css={labelStyle(selectLabelColor)}>{label}</span>
     </button>
   );
 };
@@ -67,6 +72,10 @@ const iconButtonStyle = (size: IconButtonSizeType, selectColors: string) => css`
   &:hover {
     cursor: pointer;
   }
+`;
+
+const labelStyle = (selectLabelColor: string) => css`
+  color: ${selectLabelColor};
 `;
 
 export default IconButton;

--- a/src/components/TextFilter.tsx
+++ b/src/components/TextFilter.tsx
@@ -6,22 +6,20 @@ import { fontSize, fontWeight } from '@/constants/font';
 interface TextFilterProps {
   options: string[];
   selectedIndex: number;
-  onFilterChange: (idx: number) => void;
+  setSelectedIndex: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const TextFilter: React.FC<TextFilterProps> = ({
   options,
   selectedIndex,
-  onFilterChange,
+  setSelectedIndex,
 }) => (
   <div css={textFilterStyle}>
     {options.map((option, idx) => (
       <React.Fragment key={idx}>
         <span
           css={optionStyle(idx, selectedIndex)}
-          onClick={() => {
-            onFilterChange(idx);
-          }}
+          onClick={() => setSelectedIndex(idx)}
         >
           {option}
         </span>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

IconButton, TextFilter 컴포넌트 수정

## 📋 작업 내용

- IconButton 컴포넌트에 labelColor를 지정할 수 있는 props를 추가했습니다.
- IconButton 컴포넌트의 default 색상을 gray로 지정했습니다.
- TextFilter 컴포넌트의 props 처리 방식을 PopupFilter 컴포넌트와 동일하게 수정했습니다.

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

변경된 사항의 스크린샷은 이전에 컴포넌트 구현으로 올렸던 PR 페이지에 업데이트 시켜두었습니다!
- IconButton : https://github.com/Dev-FE-1/Toy_Project_3_Team5/pull/36
- TextFilter : https://github.com/Dev-FE-1/Toy_Project_3_Team5/pull/41