### PR TITLE
[fix] 케밥버튼, 플레이리스트 카드, NavBar 컴포넌트 스타일 수정

### DIFF
--- a/src/components/KebabButton.tsx
+++ b/src/components/KebabButton.tsx
@@ -64,13 +64,14 @@ const kebabButtonStyle = css`
 
 const menuModalStyle = css`
   position: absolute;
-  top: 28px;
-  right: 0;
+  top: 30px;
+  right: 8px;
   width: 124px;
   background-color: ${colors.white};
   border-radius: 4px;
+  z-index: 10;
   box-shadow:
-    0px 3px 14px 2px rgba(0, 0, 0, 0.12),
+    0px 3px 8px 2px rgba(0, 0, 0, 0.12),
     0px 8px 10px 1px rgba(0, 0, 0, 0.14),
     0px 5px 5px -3px rgba(0, 0, 0, 0.2);
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,7 +15,7 @@ interface NavList {
 const navList: NavList[] = [
   { label: '홈', icon: Home, to: ROUTES.ROOT },
   { label: '인기', icon: Flame, to: ROUTES.POPULAR },
-  { label: '내 플리', icon: Library, to: ROUTES.PLAYLIST('1') },
+  { label: '마이플리', icon: Library, to: ROUTES.PLAYLIST('1') },
   { label: '팔로잉', icon: Users, to: ROUTES.FOLLOWING },
 ];
 

--- a/src/components/PlaylistCard.tsx
+++ b/src/components/PlaylistCard.tsx
@@ -5,6 +5,8 @@ import {
   MessageSquareMore,
   LockKeyhole,
   LockKeyholeOpen,
+  ListX,
+  ListPlus,
 } from 'lucide-react';
 import IconButton from '@/components/IconButton';
 import KebabButton from '@/components/KebabButton';
@@ -18,12 +20,24 @@ type CardSize = 'large' | 'small';
 interface PlaylistCardProps {
   playlistItem: PlayListDataProps;
   size: CardSize;
+  showAddButton?: boolean;
+  showLikeButton?: boolean;
+  showLockButton?: boolean;
+  showKebabMenu?: boolean;
 }
 
-const MAXLENGTH = 50;
+const MAXLENGTH = 20;
 
-const PlaylistCard: React.FC<PlaylistCardProps> = ({ playlistItem, size }) => {
+const PlaylistCard: React.FC<PlaylistCardProps> = ({
+  playlistItem,
+  size,
+  showAddButton = false,
+  showLikeButton = false,
+  showLockButton = false,
+  showKebabMenu = false,
+}) => {
   const [isLiked, setIsLiked] = useState(false);
+  const [isAdded, setIsAdded] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
 
   const menuItems = [
@@ -87,24 +101,37 @@ const PlaylistCard: React.FC<PlaylistCardProps> = ({ playlistItem, size }) => {
         </section>
       </div>
       <div css={smallBtnStyles}>
-        <IconButton
-          IconComponent={Heart}
-          onClick={() => setIsLiked(!isLiked)}
-          color={isLiked ? 'red' : 'gray'}
-          fillColor={isLiked ? 'red' : undefined}
-        />
-        <IconButton
-          IconComponent={isLocked ? LockKeyhole : LockKeyholeOpen}
-          onClick={() => setIsLocked(!isLocked)}
-          color='gray'
-        />
-        <KebabButton menuItems={menuItems} />
+        {showAddButton && (
+          <IconButton
+            IconComponent={isAdded ? ListX : ListPlus}
+            onClick={() => setIsAdded(!isAdded)}
+            color='gray'
+          />
+        )}
+        {showLikeButton && (
+          <IconButton
+            IconComponent={Heart}
+            onClick={() => setIsLiked(!isLiked)}
+            color={isLiked ? 'red' : 'gray'}
+            fillColor={isLiked ? 'red' : undefined}
+          />
+        )}
+        {showLockButton && (
+          <IconButton
+            IconComponent={isLocked ? LockKeyhole : LockKeyholeOpen}
+            onClick={() => setIsLocked(!isLocked)}
+            color='gray'
+          />
+        )}
+        {showKebabMenu && <KebabButton menuItems={menuItems} />}
       </div>
     </article>
   );
 
   return size === 'large' ? renderLargeCard() : renderSmallCard();
 };
+
+const smallImgSize = '72px';
 
 const largeCardStyles = css`
   gap: 8px;
@@ -191,8 +218,10 @@ const smallCardStyles = css`
   }
 
   .img-container {
-    width: 72px;
-    height: 72px;
+    width: ${smallImgSize};
+    min-width: ${smallImgSize};
+    height: ${smallImgSize};
+    min-height: ${smallImgSize};
     overflow: hidden;
     border-radius: 6px;
     display: flex;
@@ -211,7 +240,7 @@ const smallInfoStyles = css`
   gap: 6px;
 
   .title {
-    font-size: ${fontSize.lg};
+    font-size: ${fontSize.md};
   }
   .username {
     color: ${colors.gray05};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

케밥버튼, 플레이리스트 카드, NavBar 컴포넌트 스타일 수정

## 📋 작업 내용
-케밥 버튼: 미니모달 z-index 수정
-플레이리스트 카드: 아이콘 버튼을 보이고, 안보이고를 정할 수 있도록 props 추가
-NavBar: 내플리 > 마이플리로 명칭 수정



