### PR TITLE
[feature] 로그인 페이지 UI 퍼블리싱 & 기능구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
-import { User } from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
-import { ChevronLeft, Pointer, SearchIcon } from 'lucide-react';
+import { ChevronLeft, SearchIcon } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import defaultProfile from '@/assets/profile_default.png';
 import IconButton from '@/components/IconButton';
@@ -11,7 +9,7 @@ import Profile from '@/components/Profile';
 import colors from '@/constants/colors';
 import { fontSize, fontWeight } from '@/constants/font';
 import ROUTES from '@/constants/route';
-import { onUserStateChanged, db } from '@/firebase/firbaseConfig';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 type HeaderType = 'main' | 'searchResult' | 'detail';
 
@@ -22,31 +20,7 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ type, headerTitle }) => {
   const [searchText, setSearchText] = useState<string>('');
-  const [user, setUser] = useState<User | null>(null);
-  const [profileImage, setProfileImage] = useState<string>(defaultProfile);
-
-  useEffect(() => {
-    const unsubscribe = onUserStateChanged(async (user: User | null) => {
-      setUser(user);
-      if (user) {
-        try {
-          const userDocRef = doc(db, 'users', user.uid);
-          const docSnapshot = await getDoc(userDocRef);
-          if (docSnapshot.exists()) {
-            const data = docSnapshot.data();
-            if (data && data.profileImg) {
-              setProfileImage(data.profileImg);
-            }
-          }
-        } catch (error) {
-          console.error('Error fetching user data: ', error);
-        }
-      } else {
-        setProfileImage(defaultProfile);
-      }
-    });
-  }, []);
-
+  const { user, profileImage } = useAuthStore();
   const navigate = useNavigate();
 
   const onProfileClick = () => {
@@ -83,7 +57,11 @@ const Header: React.FC<HeaderProps> = ({ type, headerTitle }) => {
             />
           </div>
           <div onClick={onProfileClick} css={profileStyle}>
-            <Profile src={profileImage} alt='프로필 이미지' size='xs' />
+            <Profile
+              src={profileImage || defaultProfile}
+              alt='프로필 이미지'
+              size='xs'
+            />
           </div>
         </>
       ) : (

--- a/src/components/PlaylistCard.tsx
+++ b/src/components/PlaylistCard.tsx
@@ -12,9 +12,11 @@ import { useNavigate } from 'react-router-dom';
 import IconButton from '@/components/IconButton';
 import KebabButton from '@/components/KebabButton';
 import Modal from '@/components/Modal';
+import Toast from '@/components/Toast';
 import colors from '@/constants/colors';
 import { fontSize } from '@/constants/font';
 import ROUTES from '@/constants/route';
+import { useAuthStore } from '@/stores/useAuthStore';
 import useModalStore from '@/stores/useModalStore';
 import { PlayListDataProps } from '@/types/playlistType';
 import { omittedText } from '@/utils/textUtils';
@@ -64,6 +66,17 @@ const PlaylistCard: React.FC<PlaylistCardProps> = ({
       },
     });
   };
+  const [toastActive, setToastActive] = useState(false);
+
+  const { user } = useAuthStore();
+
+  const onClickHeart = () => {
+    if (!user) {
+      setToastActive(true);
+    } else {
+      setIsLiked(!isLiked);
+    }
+  };
 
   const menuItems = [
     {
@@ -107,7 +120,7 @@ const PlaylistCard: React.FC<PlaylistCardProps> = ({
           <div className='icon'>
             <IconButton
               IconComponent={Heart}
-              onClick={() => setIsLiked(!isLiked)}
+              onClick={onClickHeart}
               color={isLiked ? 'red' : 'gray'}
               fillColor={isLiked ? 'red' : undefined}
             />
@@ -160,7 +173,7 @@ const PlaylistCard: React.FC<PlaylistCardProps> = ({
         {showLikeButton && (
           <IconButton
             IconComponent={Heart}
-            onClick={() => setIsLiked(!isLiked)}
+            onClick={onClickHeart}
             color={isLiked ? 'red' : 'gray'}
             fillColor={isLiked ? 'red' : undefined}
           />
@@ -178,7 +191,17 @@ const PlaylistCard: React.FC<PlaylistCardProps> = ({
     </article>
   );
 
-  return size === 'large' ? renderLargeCard() : renderSmallCard();
+  return (
+    <>
+      {size === 'large' ? renderLargeCard() : renderSmallCard()}
+      <Toast
+        isActive={toastActive}
+        toastMsg='로그인이 필요합니다.'
+        status='fail'
+        onClose={() => setToastActive(false)}
+      />
+    </>
+  );
 };
 
 const smallImgSize = '72px';

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -64,7 +64,7 @@ const toastStyle = css`
   bottom: 96px; // navbar 크기만큼
   display: flex;
   align-items: center;
-  margin-left: 16px;
+  /* margin-left: 16px; */
   padding: 16px;
   border-radius: 4px;
   background-color: ${colors.gray04};

--- a/src/firebase/firbaseConfig.ts
+++ b/src/firebase/firbaseConfig.ts
@@ -1,7 +1,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { getAuth, onAuthStateChanged, User } from 'firebase/auth';
+import { getFirestore, doc, getDoc } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -17,3 +17,23 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const auth = getAuth(app);
+
+export const onUserStateChanged = (
+  callback: (user: (User & { profileImg?: string }) | null) => void
+) => {
+  onAuthStateChanged(auth, async (user) => {
+    if (user) {
+      const userDocRef = doc(db, 'users', user.uid);
+      const userDoc = await getDoc(userDocRef);
+      if (userDoc.exists()) {
+        callback({ ...user, profileImg: userDoc.data().profileImg } as User & {
+          profileImg?: string;
+        });
+      } else {
+        callback(user);
+      }
+    } else {
+      callback(null);
+    }
+  });
+};

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -27,7 +27,6 @@ export const SignIn = () => {
     try {
       const user = await signInWithEmailAndPassword(auth, email, password);
       navigate(ROUTES.ROOT);
-      return user;
     } catch (error) {
       console.error('로그인 중 오류 발생:', error);
     }
@@ -37,9 +36,7 @@ export const SignIn = () => {
     const provider = new GoogleAuthProvider();
     try {
       const result = await signInWithPopup(auth, provider);
-      const { user } = result;
       navigate(ROUTES.ROOT);
-      return user;
     } catch (error) {
       console.error('Google 로그인 중 오류 발생:', error);
     }

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -25,12 +25,9 @@ export const SignIn = () => {
   const onEmailLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
-      const userCredential = await signInWithEmailAndPassword(
-        auth,
-        email,
-        password
-      );
+      const user = await signInWithEmailAndPassword(auth, email, password);
       navigate(ROUTES.ROOT);
+      return user;
     } catch (error) {
       console.error('로그인 중 오류 발생:', error);
     }
@@ -42,6 +39,7 @@ export const SignIn = () => {
       const result = await signInWithPopup(auth, provider);
       const { user } = result;
       navigate(ROUTES.ROOT);
+      return user;
     } catch (error) {
       console.error('Google 로그인 중 오류 발생:', error);
     }

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -17,10 +17,13 @@ import ROUTES from '@/constants/route';
 import { auth } from '@/firebase/firbaseConfig';
 import { useAuthStore } from '@/stores/useAuthStore';
 
+const DOMAIN = '@gmail.com';
+
 export const SignIn = () => {
-  const [email, setEmail] = useState('');
+  const [id, setId] = useState('');
   const [password, setPassword] = useState('');
   const [isEmailRemembered, setIsEmailRemembered] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState('');
   const navigate = useNavigate();
 
   const setUser = useAuthStore((state) => state.setUser);
@@ -28,7 +31,7 @@ export const SignIn = () => {
   useEffect(() => {
     const savedEmail = localStorage.getItem('savedEmail');
     if (savedEmail) {
-      setEmail(savedEmail);
+      setId(savedEmail);
       setIsEmailRemembered(true);
     }
   }, []);
@@ -36,7 +39,7 @@ export const SignIn = () => {
   const handleToggleChange = (enabled: boolean) => {
     setIsEmailRemembered(enabled);
     if (enabled) {
-      localStorage.setItem('savedEmail', email);
+      localStorage.setItem('savedEmail', id);
     } else {
       localStorage.removeItem('savedEmail');
     }
@@ -44,7 +47,9 @@ export const SignIn = () => {
 
   const onEmailLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setErrorMessage('');
     try {
+      const email = `${id}${DOMAIN}`;
       const userCredential = await signInWithEmailAndPassword(
         auth,
         email,
@@ -54,6 +59,7 @@ export const SignIn = () => {
       navigate(ROUTES.ROOT);
     } catch (error) {
       console.error('로그인 중 오류 발생:', error);
+      setErrorMessage('아이디와 비밀번호를 확인해주세요');
     }
   };
 
@@ -65,6 +71,9 @@ export const SignIn = () => {
       navigate(ROUTES.ROOT);
     } catch (error) {
       console.error('Google 로그인 중 오류 발생:', error);
+      setErrorMessage(
+        'Google 로그인 중 오류가 발생했습니다. 다시 시도해주세요.'
+      );
     }
   };
 
@@ -72,13 +81,13 @@ export const SignIn = () => {
     navigate(ROUTES.SIGN_UP);
   };
 
-  const validateEmail = (email: string) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email) ? '' : '올바른 이메일 주소를 입력해주세요';
-  };
+  const validateId = (id: string) =>
+    id.length > 0 ? '' : '아이디를 입력해주세요';
 
   const validatePassword = (value: string) =>
-    value.length >= 6 ? '' : '비밀번호를 확인해주세요';
+    value.length > 0 ? '' : '비밀번호를 확인해주세요';
+
+  const isLoginDisabled = id.length === 0 || password.length === 0;
 
   return (
     <div css={containerStyle}>
@@ -87,12 +96,12 @@ export const SignIn = () => {
       </div>
       <form onSubmit={onEmailLogin}>
         <InputBox
-          label='이메일'
-          placeholder='이메일'
-          value={email}
-          validate={validateEmail}
+          label='아이디'
+          placeholder='아이디'
+          value={id}
+          validate={validateId}
           onChange={(e) => {
-            setEmail(e.target.value);
+            setId(e.target.value);
             if (isEmailRemembered) {
               localStorage.setItem('savedEmail', e.target.value);
             }
@@ -106,6 +115,7 @@ export const SignIn = () => {
           onChange={(e) => setPassword(e.target.value)}
           isPassword
         />
+        {errorMessage && <div css={errorMessageStyle}>{errorMessage}</div>}
         <div css={toggleStyle}>
           <Toggle
             enabled={isEmailRemembered}
@@ -113,7 +123,14 @@ export const SignIn = () => {
             label={{ active: '로그인 정보 기억하기', inactive: '' }}
           />
         </div>
-        <Button label='로그인' size='lg' fullWidth={true} type='submit' />
+        <Button
+          label='로그인'
+          size='lg'
+          fullWidth={true}
+          type='submit'
+          onClick={() => {}}
+          disabled={isLoginDisabled}
+        />
         <div css={loginBtnStyle}>
           <div css={lineStyle}></div>
           <Button
@@ -175,4 +192,11 @@ const signUpStyle = css`
   &:hover {
     font-weight: ${fontWeight.semiBold};
   }
+`;
+
+const errorMessageStyle = css`
+  color: ${colors.redNormal};
+  font-size: ${fontSize.sm};
+  margin-bottom: 10px;
+  margin-top: -10px;
 `;

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -1,3 +1,104 @@
-import React from 'react';
+import { useState } from 'react';
+import { css } from '@emotion/react';
+import { useNavigate } from 'react-router-dom';
+import google from '@/assets/google_icon.svg';
+import Button from '@/components/Button';
+import InputBox from '@/components/InputBox';
+import Logo from '@/components/Logo';
+import Toggle from '@/components/Toggle';
+import colors from '@/constants/colors';
+import { fontSize, fontWeight } from '@/constants/font';
+import ROUTES from '@/constants/route';
 
-export const SignIn = () => <div>SignIn 로그인 페이지</div>;
+export const SignIn = () => {
+  const [a, seta] = useState<boolean>(false);
+  const navigate = useNavigate();
+
+  const onSignUpClick = (): void => {
+    navigate(ROUTES.SIGN_UP);
+  };
+
+  const validatePassword = (value: string) =>
+    value.length >= 6 ? '' : '비밀번호를 확인해주세요';
+
+  return (
+    <div css={containerStyle}>
+      <div style={{ marginBottom: '20px' }}>
+        <Logo logoWidth={180} clickable={false} />
+      </div>
+      <InputBox label='아이디' placeholder='아이디' />
+      <InputBox
+        label='비밀번호'
+        placeholder='비밀번호'
+        validate={validatePassword}
+        isPassword
+      />
+      <div css={toggleStyle}>
+        <Toggle
+          enabled={a}
+          setEnabled={seta}
+          label={{ active: '로그인 정보 기억하기', inactive: '' }}
+        />
+      </div>
+      <div css={loginBtnStyle}>
+        <Button label='로그인' onClick={() => {}} size='lg' fullWidth={true} />
+        <div css={lineStyle}></div>
+        <Button
+          label='또는 구글로 로그인'
+          onClick={() => {}}
+          size='lg'
+          color='black'
+          IconComponent={google}
+          fullWidth={true}
+        />
+      </div>
+      <div css={signUpMessageStyle}>
+        계정이 없으신가요?{' '}
+        <span onClick={onSignUpClick} css={signUpStyle}>
+          회원가입하기
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const containerStyle = css`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const toggleStyle = css`
+  width: 390px;
+  height: 20px;
+  margin: 6px 0 14px 0;
+  font-size: ${fontSize.sm};
+`;
+
+const loginBtnStyle = css`
+  width: 390px;
+  margin-bottom: 10px;
+`;
+
+const lineStyle = css`
+  width: 390px;
+  height: 0.5px;
+  background-color: ${colors.gray02};
+  margin: 20px 0;
+`;
+
+const signUpMessageStyle = css`
+  font-size: ${fontSize.sm};
+`;
+
+const signUpStyle = css`
+  color: ${colors.primaryNormal};
+  cursor: pointer;
+
+  &:hover {
+    font-weight: ${fontWeight.semiBold};
+  }
+`;

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -15,12 +15,15 @@ import colors from '@/constants/colors';
 import { fontSize, fontWeight } from '@/constants/font';
 import ROUTES from '@/constants/route';
 import { auth } from '@/firebase/firbaseConfig';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 export const SignIn = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isEmailRemembered, setIsEmailRemembered] = useState<boolean>(false);
   const navigate = useNavigate();
+
+  const setUser = useAuthStore((state) => state.setUser);
 
   useEffect(() => {
     const savedEmail = localStorage.getItem('savedEmail');
@@ -42,7 +45,12 @@ export const SignIn = () => {
   const onEmailLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
-      const user = await signInWithEmailAndPassword(auth, email, password);
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+      setUser(userCredential.user);
       navigate(ROUTES.ROOT);
     } catch (error) {
       console.error('로그인 중 오류 발생:', error);
@@ -53,6 +61,7 @@ export const SignIn = () => {
     const provider = new GoogleAuthProvider();
     try {
       const result = await signInWithPopup(auth, provider);
+      setUser(result.user);
       navigate(ROUTES.ROOT);
     } catch (error) {
       console.error('Google 로그인 중 오류 발생:', error);

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 import {
   signInWithEmailAndPassword,
@@ -19,8 +19,25 @@ import { auth } from '@/firebase/firbaseConfig';
 export const SignIn = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [a, seta] = useState<boolean>(false);
+  const [isEmailRemembered, setIsEmailRemembered] = useState<boolean>(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const savedEmail = localStorage.getItem('savedEmail');
+    if (savedEmail) {
+      setEmail(savedEmail);
+      setIsEmailRemembered(true);
+    }
+  }, []);
+
+  const handleToggleChange = (enabled: boolean) => {
+    setIsEmailRemembered(enabled);
+    if (enabled) {
+      localStorage.setItem('savedEmail', email);
+    } else {
+      localStorage.removeItem('savedEmail');
+    }
+  };
 
   const onEmailLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -65,7 +82,12 @@ export const SignIn = () => {
           placeholder='이메일'
           value={email}
           validate={validateEmail}
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={(e) => {
+            setEmail(e.target.value);
+            if (isEmailRemembered) {
+              localStorage.setItem('savedEmail', e.target.value);
+            }
+          }}
         />
         <InputBox
           label='비밀번호'
@@ -77,8 +99,8 @@ export const SignIn = () => {
         />
         <div css={toggleStyle}>
           <Toggle
-            enabled={a}
-            setEnabled={seta}
+            enabled={isEmailRemembered}
+            setEnabled={handleToggleChange}
             label={{ active: '로그인 정보 기억하기', inactive: '' }}
           />
         </div>

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -1,5 +1,10 @@
 import { useState } from 'react';
 import { css } from '@emotion/react';
+import {
+  signInWithEmailAndPassword,
+  GoogleAuthProvider,
+  signInWithPopup,
+} from 'firebase/auth';
 import { useNavigate } from 'react-router-dom';
 import google from '@/assets/google_icon.svg';
 import Button from '@/components/Button';
@@ -9,13 +14,46 @@ import Toggle from '@/components/Toggle';
 import colors from '@/constants/colors';
 import { fontSize, fontWeight } from '@/constants/font';
 import ROUTES from '@/constants/route';
+import { auth } from '@/firebase/firbaseConfig';
 
 export const SignIn = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const [a, seta] = useState<boolean>(false);
   const navigate = useNavigate();
 
-  const onSignUpClick = (): void => {
+  const onEmailLogin = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+      navigate(ROUTES.ROOT);
+    } catch (error) {
+      console.error('로그인 중 오류 발생:', error);
+    }
+  };
+
+  const onGoogleLogin = async () => {
+    const provider = new GoogleAuthProvider();
+    try {
+      const result = await signInWithPopup(auth, provider);
+      const { user } = result;
+      navigate(ROUTES.ROOT);
+    } catch (error) {
+      console.error('Google 로그인 중 오류 발생:', error);
+    }
+  };
+
+  const onSignUpMessage = (): void => {
     navigate(ROUTES.SIGN_UP);
+  };
+
+  const validateEmail = (email: string) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email) ? '' : '올바른 이메일 주소를 입력해주세요';
   };
 
   const validatePassword = (value: string) =>
@@ -26,35 +64,45 @@ export const SignIn = () => {
       <div style={{ marginBottom: '20px' }}>
         <Logo logoWidth={180} clickable={false} />
       </div>
-      <InputBox label='아이디' placeholder='아이디' />
-      <InputBox
-        label='비밀번호'
-        placeholder='비밀번호'
-        validate={validatePassword}
-        isPassword
-      />
-      <div css={toggleStyle}>
-        <Toggle
-          enabled={a}
-          setEnabled={seta}
-          label={{ active: '로그인 정보 기억하기', inactive: '' }}
+      <form onSubmit={onEmailLogin}>
+        <InputBox
+          label='이메일'
+          placeholder='이메일'
+          value={email}
+          validate={validateEmail}
+          onChange={(e) => setEmail(e.target.value)}
         />
-      </div>
-      <div css={loginBtnStyle}>
-        <Button label='로그인' onClick={() => {}} size='lg' fullWidth={true} />
-        <div css={lineStyle}></div>
-        <Button
-          label='또는 구글로 로그인'
-          onClick={() => {}}
-          size='lg'
-          color='black'
-          IconComponent={google}
-          fullWidth={true}
+        <InputBox
+          label='비밀번호'
+          placeholder='비밀번호'
+          value={password}
+          validate={validatePassword}
+          onChange={(e) => setPassword(e.target.value)}
+          isPassword
         />
-      </div>
+        <div css={toggleStyle}>
+          <Toggle
+            enabled={a}
+            setEnabled={seta}
+            label={{ active: '로그인 정보 기억하기', inactive: '' }}
+          />
+        </div>
+        <Button label='로그인' size='lg' fullWidth={true} type='submit' />
+        <div css={loginBtnStyle}>
+          <div css={lineStyle}></div>
+          <Button
+            label='또는 구글로 로그인'
+            onClick={onGoogleLogin}
+            size='lg'
+            color='black'
+            IconComponent={google}
+            fullWidth={true}
+          />
+        </div>
+      </form>
       <div css={signUpMessageStyle}>
         계정이 없으신가요?{' '}
-        <span onClick={onSignUpClick} css={signUpStyle}>
+        <span onClick={onSignUpMessage} css={signUpStyle}>
           회원가입하기
         </span>
       </div>

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -2,8 +2,6 @@ import { Outlet } from 'react-router-dom';
 
 export const Profile = () => (
   <>
-    <div>Profile Header</div>
     <Outlet />
-    <div>Profile Footer</div>
   </>
 );

--- a/src/pages/profile/ProfileHome.tsx
+++ b/src/pages/profile/ProfileHome.tsx
@@ -1,7 +1,5 @@
-import { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
-import { signOut, User } from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
+import { signOut } from 'firebase/auth';
 import { Trash2, LogOut } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import Button from '@/components/Button';
@@ -11,7 +9,8 @@ import Profile from '@/components/Profile';
 import colors from '@/constants/colors';
 import { fontSize, fontWeight } from '@/constants/font';
 import ROUTES from '@/constants/route';
-import { auth, onUserStateChanged, db } from '@/firebase/firbaseConfig';
+import { auth } from '@/firebase/firbaseConfig';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 const comments = [
   {
@@ -32,55 +31,25 @@ const comments = [
 ];
 
 export const ProfileHome = () => {
-  const [profileImage, setProfileImage] = useState<string>('');
-  const [user, setUser] = useState<User | null>(null);
-  const [channelName, setChannelName] = useState<string>('');
-  const [playlist, setPlaylist] = useState<number>(0);
-  const [channelFollower, setChannelFollower] = useState<number>(0);
-  const [channelFollowing, setChannelFollowing] = useState<number>(0);
+  const navigate = useNavigate();
+  const {
+    profileImage,
+    channelName,
+    playlistCount,
+    followerCount,
+    followingCount,
+    clearUser,
+  } = useAuthStore();
 
   const infoData = [
-    { count: playlist, label: '플레이리스트' },
-    { count: channelFollower, label: '팔로워' },
-    { count: channelFollowing, label: '팔로잉' },
+    { count: playlistCount, label: '플레이리스트' },
+    { count: followerCount, label: '팔로워' },
+    { count: followingCount, label: '팔로잉' },
   ];
-
-  useEffect(() => {
-    onUserStateChanged(async (user: User | null) => {
-      setUser(user);
-      if (user) {
-        try {
-          const userDocRef = doc(db, 'users', user.uid);
-          const docSnapshot = await getDoc(userDocRef);
-          if (docSnapshot.exists()) {
-            const data = docSnapshot.data();
-            if (data && data.profileImg) {
-              setProfileImage(data.profileImg);
-            }
-            if (data && data.channelName) {
-              setChannelName(data.channelName);
-            }
-            if (data && data.followingPlaylist) {
-              setPlaylist(data.followingPlaylist.length);
-            }
-            if (data && data.channelFollower) {
-              setChannelFollower(data.channelFollower.length);
-            }
-            if (data && data.channelFollowing) {
-              setChannelFollowing(data.channelFollowing.length);
-            }
-          }
-        } catch (error) {
-          console.error('Error fetching user data: ', error);
-        }
-      }
-    });
-  }, []);
-
-  const navigate = useNavigate();
 
   const logout = async () => {
     await signOut(auth).then(() => {
+      clearUser();
       navigate(ROUTES.ROOT);
     });
   };

--- a/src/pages/profile/ProfileHome.tsx
+++ b/src/pages/profile/ProfileHome.tsx
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
+import { signOut } from 'firebase/auth';
 import { Trash2, LogOut } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import defaultProfile from '@/assets/profile_default.png';
 import Button from '@/components/Button';
 import CheckBox from '@/components/CheckBox';
@@ -7,6 +9,8 @@ import IconButton from '@/components/IconButton';
 import Profile from '@/components/Profile';
 import colors from '@/constants/colors';
 import { fontSize, fontWeight } from '@/constants/font';
+import ROUTES from '@/constants/route';
+import { auth } from '@/firebase/firbaseConfig';
 
 const infoData = [
   { count: 54, label: '플레이리스트' },
@@ -32,63 +36,73 @@ const comments = [
   },
 ];
 
-export const ProfileHome = () => (
-  <div css={containerStyle}>
-    <div css={profileContainerStyle}>
-      <Profile src={defaultProfile} alt='프로필 이미지' size='xl' />
-      <span css={profileNameStyle}>Irene</span>
-      <button css={profileBtnStyle}>프로필 수정</button>
-      <div css={infoContainerStyle}>
-        {infoData.map(({ count, label }) => (
-          <div key={label} css={infoStyle}>
-            <div>{count}</div>
-            <div>{label}</div>
-          </div>
-        ))}
+export const ProfileHome = () => {
+  const navigate = useNavigate();
+
+  const logout = async () => {
+    await signOut(auth).then(() => {
+      navigate(ROUTES.ROOT);
+    });
+  };
+
+  return (
+    <div css={containerStyle}>
+      <div css={profileContainerStyle}>
+        <Profile src={defaultProfile} alt='프로필 이미지' size='xl' />
+        <span css={profileNameStyle}>Irene</span>
+        <button css={profileBtnStyle}>프로필 수정</button>
+        <div css={infoContainerStyle}>
+          {infoData.map(({ count, label }) => (
+            <div key={label} css={infoStyle}>
+              <div>{count}</div>
+              <div>{label}</div>
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
-    <div css={commentContainerStyle}>
-      <div css={commentHeaderStyle}>내가 쓴 댓글 30</div>
-      <div css={deleteContainerStyle}>
-        <button css={allSelectBtnStyle}>전체 선택</button>
-        <IconButton
-          IconComponent={Trash2}
+      <div css={commentContainerStyle}>
+        <div css={commentHeaderStyle}>내가 쓴 댓글 30</div>
+        <div css={deleteContainerStyle}>
+          <button css={allSelectBtnStyle}>전체 선택</button>
+          <IconButton
+            IconComponent={Trash2}
+            onClick={() => {}}
+            size='md'
+            color='red'
+          />
+        </div>
+        <ul css={commentSelectStyle}>
+          {comments.map(({ id, ply, text }) => (
+            <li key={id} css={commentStyle}>
+              <CheckBox />
+              <Profile src={defaultProfile} alt='프로필 이미지' size='sm' />
+              <div css={commentDesStyle}>
+                <span>{ply}</span>
+                <div>{text}</div>
+              </div>
+            </li>
+          ))}
+        </ul>
+        <Button
+          label='더보기'
           onClick={() => {}}
-          size='md'
-          color='red'
+          size='lg'
+          fullWidth
+          color='gray'
         />
       </div>
-      <ul css={commentSelectStyle}>
-        {comments.map(({ id, ply, text }) => (
-          <li key={id} css={commentStyle}>
-            <CheckBox />
-            <Profile src={defaultProfile} alt='프로필 이미지' size='sm' />
-            <div css={commentDesStyle}>
-              <span>{ply}</span>
-              <div>{text}</div>
-            </div>
-          </li>
-        ))}
-      </ul>
-      <Button
-        label='더보기'
-        onClick={() => {}}
-        size='lg'
-        fullWidth
-        color='gray'
-      />
+      <div css={logoutStyle} onClick={logout}>
+        <IconButton
+          IconComponent={LogOut}
+          onClick={logout}
+          size='md'
+          color='gray'
+        />
+        로그아웃
+      </div>
     </div>
-    <div css={logoutStyle}>
-      <IconButton
-        IconComponent={LogOut}
-        onClick={() => {}}
-        size='md'
-        color='gray'
-      />
-      로그아웃
-    </div>
-  </div>
-);
+  );
+};
 
 const containerStyle = css`
   display: flex;

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import React, { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import ROUTES from '@/constants/route';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const { user } = useAuthStore();
+
+  if (!user) {
+    return <Navigate to={ROUTES.SIGN_IN} replace />;
+  }
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,5 +1,4 @@
 // src/router.js
-
 import { createBrowserRouter } from 'react-router-dom';
 import { Layout } from '@/components/Layout';
 import ROUTES from '@/constants/route';
@@ -23,6 +22,7 @@ import { ProfileFollower } from '@/pages/profile/ProfileFollower';
 import { ProfileFollowing } from '@/pages/profile/ProfileFollowing';
 import { ProfileHome } from '@/pages/profile/ProfileHome';
 import { ProfileUpdate } from '@/pages/profile/ProfileUpdate';
+import ProtectedRoute from '@/router/ProtectedRoute';
 
 export const router = createBrowserRouter([
   {
@@ -35,7 +35,11 @@ export const router = createBrowserRouter([
       },
       {
         path: ROUTES.PLAYLIST(),
-        element: <PlayList />,
+        element: (
+          <ProtectedRoute>
+            <PlayList />
+          </ProtectedRoute>
+        ),
         children: [
           {
             index: true,
@@ -57,11 +61,19 @@ export const router = createBrowserRouter([
       },
       {
         path: ROUTES.PLAYLIST_MODIFY(),
-        element: <PlayListUpdate />,
+        element: (
+          <ProtectedRoute>
+            <PlayListUpdate />
+          </ProtectedRoute>
+        ),
       },
       {
         path: ROUTES.PROFILE(),
-        element: <Profile />,
+        element: (
+          <ProtectedRoute>
+            <Profile />
+          </ProtectedRoute>
+        ),
         children: [
           {
             index: true,
@@ -83,7 +95,11 @@ export const router = createBrowserRouter([
       },
       {
         path: ROUTES.FOLLOWING,
-        element: <Following />,
+        element: (
+          <ProtectedRoute>
+            <Following />
+          </ProtectedRoute>
+        ),
       },
       {
         path: ROUTES.SEARCH(),

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,0 +1,54 @@
+import { User } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+import { create } from 'zustand';
+import { auth, db, onUserStateChanged } from '@/firebase/firbaseConfig';
+
+interface AuthState {
+  user: User | null;
+  profileImage: string;
+  channelName: string;
+  playlistCount: number;
+  followerCount: number;
+  followingCount: number;
+  setUser: (user: User | null) => void;
+  clearUser: () => void;
+  fetchUserData: (uid: string) => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  profileImage: '',
+  channelName: '',
+  playlistCount: 0,
+  followerCount: 0,
+  followingCount: 0,
+
+  setUser: (user) => set({ user }),
+  clearUser: () =>
+    set({
+      user: null,
+      profileImage: '',
+    }),
+  fetchUserData: async (uid) => {
+    const userDocRef = doc(db, 'users', uid);
+    const docSnapshot = await getDoc(userDocRef);
+    if (docSnapshot.exists()) {
+      const data = docSnapshot.data();
+      set({
+        profileImage: data?.profileImg || '',
+        channelName: data?.channelName || '',
+        playlistCount: data?.followingPlaylist?.length || 0,
+        followerCount: data?.channelFollower?.length || 0,
+        followingCount: data?.channelFollowing?.length || 0,
+      });
+    }
+  },
+}));
+
+onUserStateChanged((user) => {
+  const { setUser, fetchUserData } = useAuthStore.getState();
+  setUser(user);
+  if (user) {
+    fetchUserData(user.uid);
+  }
+});


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

로그인 페이지 UI 퍼블리싱 & 기능구현

## 📋 작업 내용

- 로그인 UI 작업
- 파이어베이스 연결
- 아이디 로그인
- 구글 로그인
- 로그인 정보 기억하기
- 로그아웃
- 로그인 사용자 정보 받아오기
  - 헤더
  - 마이페이지
- 로그인 유효성 검사

### 비회원 리다이렉트
- 메인 페이지에서 좋아요 누른 경우  -> 토스트
- 마이플리 페이지 누른 경우
- 팔로잉 페이지 누른 경우
- 우측 상단 프로필 이미지 누른 경우

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b1c7e409-7bb0-4cc8-bea9-7f1d86be3c2f">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6c4ad910-6f69-40f1-87db-d43167783286">
<img width="396" alt="image" src="https://github.com/user-attachments/assets/7e68f3dc-4dfe-49fb-a584-06bb77f5802b">
<img width="403" alt="image" src="https://github.com/user-attachments/assets/79b94631-5d54-4fd4-b730-49b3716eced9">


## 📄 기타

useAuthStore.ts
```
interface AuthState {
  user: User | null; // 로그인된 사용자 정보
  profileImage: string; // 프로필 이미지 URL
  channelName: string; // 채널 이름
  playlistCount: number; // 플레이리스트 수
  followerCount: number; // 팔로워 수
  followingCount: number; // 팔로우 수
  setUser: (user: User | null) => void; // 사용자 설정 함수
  clearUser: () => void; // 로그아웃할 때 초기화 함수
  fetchUserData: (uid: string) => void; // Firestore에서 데이터 가져오는 함수
}
```
