### PR TITLE
[feature] 회원가입 & 해시태그 페이지 기능 구현

### DIFF
--- a/src/components/HashTag.tsx
+++ b/src/components/HashTag.tsx
@@ -11,9 +11,9 @@ export interface Tag {
 
 interface TagProps {
   tags: Tag[];
-  onRemove: (id: number) => void;
+  onRemove: (label: string) => void;
   margin?: string;
-  onTagClick?: (id: number, removable: boolean) => void;
+  onTagClick?: (label: string, removable: boolean) => void;
 }
 
 const HashTag: React.FC<TagProps> = ({
@@ -24,10 +24,10 @@ const HashTag: React.FC<TagProps> = ({
 }) => {
   const { selectedTags, onTagSelection } = useTagSelection();
 
-  const onSelectedTagClick = (id: number, removable: boolean) => {
-    onTagSelection(id, removable);
+  const onSelectedTagClick = (label: string, removable: boolean) => {
+    onTagSelection(label, removable);
     if (onTagClick) {
-      onTagClick(id, removable);
+      onTagClick(label, removable);
     }
   };
 
@@ -36,8 +36,12 @@ const HashTag: React.FC<TagProps> = ({
       {tags.map((tag) => (
         <div
           key={tag.id}
-          css={tagStyle(selectedTags.includes(tag.id), tag.removable, margin)}
-          onClick={() => onSelectedTagClick(tag.id, tag.removable)}
+          css={tagStyle(
+            selectedTags.includes(tag.label),
+            tag.removable,
+            margin
+          )}
+          onClick={() => onSelectedTagClick(tag.label, tag.removable)}
         >
           {tag.label}
           {tag.removable && (
@@ -45,7 +49,7 @@ const HashTag: React.FC<TagProps> = ({
               css={removeButtonStyle}
               onClick={(e) => {
                 e.stopPropagation();
-                onRemove(tag.id);
+                onRemove(tag.label);
               }}
             >
               X

--- a/src/firebase/firbaseConfig.ts
+++ b/src/firebase/firbaseConfig.ts
@@ -1,7 +1,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from 'firebase/app';
-import { getAuth, onAuthStateChanged, User } from 'firebase/auth';
-import { getFirestore, doc, getDoc } from 'firebase/firestore';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
@@ -19,26 +19,6 @@ const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
 export const auth = getAuth(app);
-
-export const onUserStateChanged = (
-  callback: (user: (User & { profileImg?: string }) | null) => void
-) => {
-  onAuthStateChanged(auth, async (user) => {
-    if (user) {
-      const userDocRef = doc(db, 'users', user.uid);
-      const userDoc = await getDoc(userDocRef);
-      if (userDoc.exists()) {
-        callback({ ...user, profileImg: userDoc.data().profileImg } as User & {
-          profileImg?: string;
-        });
-      } else {
-        callback(user);
-      }
-    } else {
-      callback(null);
-    }
-  });
-};
 
 export const COLLECTION = {
   users: 'users',

--- a/src/hooks/useTagSelection.ts
+++ b/src/hooks/useTagSelection.ts
@@ -1,20 +1,20 @@
 import { useState } from 'react';
 
-const useTagSelection = (initialSelectedTags: number[] = []) => {
+const useTagSelection = (initialSelectedTags: string[] = []) => {
   const [selectedTags, setSelectedTags] =
-    useState<number[]>(initialSelectedTags);
+    useState<string[]>(initialSelectedTags);
 
-  const onTagSelection = (id: number, removable: boolean) => {
+  const onTagSelection = (label: string, removable: boolean) => {
     if (removable) return;
 
     setSelectedTags((prev) => {
-      if (prev.includes(id)) {
-        return prev.filter((tagId) => tagId !== id);
+      if (prev.includes(label)) {
+        return prev.filter((tagLabel) => tagLabel !== label);
       } else {
         if (prev.length >= 10) {
           return prev;
         }
-        return [...prev, id];
+        return [...prev, label];
       }
     });
   };

--- a/src/pages/common/HashTag.tsx
+++ b/src/pages/common/HashTag.tsx
@@ -9,22 +9,27 @@ import { fontSize, fontWeight } from '@/constants/font';
 import { HASHTAGS } from '@/constants/hashtag';
 import ROUTES from '@/constants/route';
 import useTagSelection from '@/hooks/useTagSelection';
+import { updateFirstLogin, useAuthStore } from '@/stores/useAuthStore';
 
 const HashTag: React.FC = () => {
   const [tags, setTags] = useState<Tag[]>(HASHTAGS);
   const { selectedTags, onTagSelection } = useTagSelection();
   const navigate = useNavigate();
 
-  const onTagRemove = (id: number) => {
-    setTags(tags.filter((tag) => tag.id !== id));
-    onTagSelection(id, true);
+  const { userId } = useAuthStore();
+
+  const onTagRemove = (label: string) => {
+    setTags(tags.filter((tag) => tag.label !== label));
+    onTagSelection(label, true);
   };
 
-  const onTagClick = (id: number, removable: boolean) => {
-    onTagSelection(id, removable);
+  const onTagClick = (label: string, removable: boolean) => {
+    onTagSelection(label, removable);
   };
 
-  const onSkip = () => {
+  const onSkip = async () => {
+    await updateFirstLogin(userId, selectedTags);
+    useAuthStore.setState({ isFirstLogin: false });
     navigate(ROUTES.ROOT);
   };
 

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -10,6 +10,7 @@ import google from '@/assets/google_icon.svg';
 import Button from '@/components/Button';
 import InputBox from '@/components/InputBox';
 import Logo from '@/components/Logo';
+import Toast from '@/components/Toast';
 import Toggle from '@/components/Toggle';
 import colors from '@/constants/colors';
 import { fontSize, fontWeight } from '@/constants/font';
@@ -158,6 +159,7 @@ export const SignIn = () => {
           회원가입하기
         </span>
       </div>
+      <Toast />
     </div>
   );
 };

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -27,6 +27,7 @@ export const SignIn = () => {
   const navigate = useNavigate();
 
   const setUser = useAuthStore((state) => state.setUser);
+  const isFirstLogin = useAuthStore((state) => state.isFirstLogin);
 
   useEffect(() => {
     const savedEmail = localStorage.getItem('savedEmail');
@@ -56,7 +57,11 @@ export const SignIn = () => {
         password
       );
       setUser(userCredential.user);
-      navigate(ROUTES.ROOT);
+      if (isFirstLogin) {
+        navigate(ROUTES.HASH_TAG);
+      } else {
+        navigate(ROUTES.ROOT);
+      }
     } catch (error) {
       console.error('로그인 중 오류 발생:', error);
       setErrorMessage('아이디와 비밀번호를 확인해주세요');
@@ -68,7 +73,11 @@ export const SignIn = () => {
     try {
       const result = await signInWithPopup(auth, provider);
       setUser(result.user);
-      navigate(ROUTES.ROOT);
+      if (isFirstLogin) {
+        navigate(ROUTES.HASH_TAG);
+      } else {
+        navigate(ROUTES.ROOT);
+      }
     } catch (error) {
       console.error('Google 로그인 중 오류 발생:', error);
       setErrorMessage(

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -101,63 +101,66 @@ export const SignIn = () => {
 
   return (
     <div css={containerStyle}>
-      <div style={{ marginBottom: '20px' }}>
-        <Logo logoWidth={180} clickable={false} />
-      </div>
-      <form onSubmit={onEmailLogin}>
-        <InputBox
-          label='아이디'
-          placeholder='아이디'
-          value={id}
-          validate={validateId}
-          onChange={(e) => {
-            setId(e.target.value);
-            if (isEmailRemembered) {
-              localStorage.setItem('savedEmail', e.target.value);
-            }
-          }}
-        />
-        <InputBox
-          label='비밀번호'
-          placeholder='비밀번호'
-          value={password}
-          validate={validatePassword}
-          onChange={(e) => setPassword(e.target.value)}
-          isPassword
-        />
-        {errorMessage && <div css={errorMessageStyle}>{errorMessage}</div>}
-        <div css={toggleStyle}>
-          <Toggle
-            enabled={isEmailRemembered}
-            setEnabled={onToggleChange}
-            label={{ active: '로그인 정보 기억하기', inactive: '' }}
-          />
+      <div css={formStyle}>
+        <div style={{ marginBottom: '20px' }}>
+          <Logo logoWidth={180} clickable={false} />
         </div>
-        <Button
-          label='로그인'
-          size='lg'
-          fullWidth={true}
-          type='submit'
-          onClick={() => {}}
-          disabled={isLoginDisabled}
-        />
-        <div css={loginBtnStyle}>
-          <div css={lineStyle}></div>
+        <form onSubmit={onEmailLogin}>
+          <InputBox
+            label='아이디'
+            placeholder='아이디'
+            value={id}
+            validate={validateId}
+            onChange={(e) => {
+              setId(e.target.value);
+              if (isEmailRemembered) {
+                localStorage.setItem('savedEmail', e.target.value);
+              }
+            }}
+          />
+          <InputBox
+            label='비밀번호'
+            placeholder='비밀번호'
+            value={password}
+            validate={validatePassword}
+            onChange={(e) => setPassword(e.target.value)}
+            isPassword
+          />
+          {errorMessage && <div css={errorMessageStyle}>{errorMessage}</div>}
+          <div css={toggleStyle}>
+            <Toggle
+              enabled={isEmailRemembered}
+              setEnabled={onToggleChange}
+              label={{ active: '로그인 정보 기억하기', inactive: '' }}
+            />
+            <div style={{ position: 'absolute', marginRight: '20px' }}></div>
+          </div>
           <Button
-            label='또는 구글로 로그인'
-            onClick={onGoogleLogin}
+            label='로그인'
             size='lg'
-            color='black'
-            IconComponent={google}
             fullWidth={true}
+            type='submit'
+            onClick={() => {}}
+            disabled={isLoginDisabled}
           />
+          <div css={loginBtnStyle}>
+            <div css={lineStyle}></div>
+            <Button
+              label='또는 구글로 로그인'
+              onClick={onGoogleLogin}
+              size='lg'
+              color='black'
+              IconComponent={google}
+              fullWidth={true}
+            />
+          </div>
+        </form>
+        <div css={signUpMessageStyle}>
+          계정이 없으신가요?{' '}
+          <span onClick={onSignUpMessage} css={signUpStyle}>
+            회원가입하기
+          </span>
         </div>
-      </form>
-      <div css={signUpMessageStyle}>
-        계정이 없으신가요?{' '}
-        <span onClick={onSignUpMessage} css={signUpStyle}>
-          회원가입하기
-        </span>
       </div>
       <Toast />
     </div>
@@ -169,10 +172,10 @@ const containerStyle = css`
   max-width: 430px;
   height: 100%;
   margin: 0 auto;
-  display: flex;
+  /* display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
+  align-items: center; */
 
   &::before {
     left: 50%;
@@ -194,6 +197,15 @@ const containerStyle = css`
     content: '';
     z-index: 11;
   }
+`;
+
+const formStyle = css`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 `;
 
 const toggleStyle = css`

--- a/src/pages/common/SignIn.tsx
+++ b/src/pages/common/SignIn.tsx
@@ -166,11 +166,34 @@ export const SignIn = () => {
 
 const containerStyle = css`
   width: 100%;
-  height: 100vh;
+  max-width: 430px;
+  height: 100%;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+
+  &::before {
+    left: 50%;
+    transform: translateX(-215px);
+  }
+
+  &::after {
+    right: 50%;
+    transform: translateX(215px);
+  }
+
+  &::before,
+  &::after {
+    width: 1px;
+    position: fixed;
+    top: 0px;
+    bottom: 0px;
+    background-color: ${colors.gray02};
+    content: '';
+    z-index: 11;
+  }
 `;
 
 const toggleStyle = css`

--- a/src/pages/common/SignUp.tsx
+++ b/src/pages/common/SignUp.tsx
@@ -15,6 +15,7 @@ import Button from '@/components/Button';
 import Header from '@/components/Header';
 import InputBox from '@/components/InputBox';
 import Toast from '@/components/Toast';
+import colors from '@/constants/colors';
 import ROUTES from '@/constants/route';
 import { auth, db } from '@/firebase/firbaseConfig';
 import useToast from '@/hooks/useToast';
@@ -252,6 +253,27 @@ const containerStyle = css`
   width: 100%;
   max-width: 430px;
   margin: 0 auto;
+
+  &::before {
+    left: 50%;
+    transform: translateX(-215px);
+  }
+
+  &::after {
+    right: 50%;
+    transform: translateX(215px);
+  }
+
+  &::before,
+  &::after {
+    width: 1px;
+    position: fixed;
+    top: 0px;
+    bottom: 0px;
+    background-color: ${colors.gray02};
+    content: '';
+    z-index: 11;
+  }
 `;
 
 const signUpContainerStyle = css`

--- a/src/pages/common/SignUp.tsx
+++ b/src/pages/common/SignUp.tsx
@@ -10,6 +10,7 @@ import {
   setDoc,
   getDoc,
 } from 'firebase/firestore';
+import { useNavigate } from 'react-router-dom';
 import Button from '@/components/Button';
 import Header from '@/components/Header';
 import InputBox from '@/components/InputBox';
@@ -31,6 +32,8 @@ export const SignUp = () => {
   const [isIdChecked, setIsIdChecked] = useState<boolean>(false);
   const [isChannelNameChecked, setIsChannelNameChecked] =
     useState<boolean>(false);
+
+  const navigate = useNavigate();
 
   const { toastTrigger } = useToast();
 
@@ -91,7 +94,7 @@ export const SignUp = () => {
     e.preventDefault();
 
     if (!isIdChecked || !isChannelNameChecked) {
-      toastTrigger('중복 검사를 진행해주세요.');
+      toastTrigger('중복 검사를 진행해주세요.', 'fail');
       return;
     }
 
@@ -120,11 +123,10 @@ export const SignUp = () => {
         likedPlaylist: [],
         profileImg: '',
         tags: [],
+        isFirstLogin: false,
       });
-      toastTrigger('회원가입 완료!🥳 로그인 화면으로 돌아가 로그인해주세요.');
-      setTimeout(() => {
-        window.location.href = ROUTES.SIGN_IN;
-      }, 2000);
+      navigate(ROUTES.SIGN_IN);
+      toastTrigger('회원가입이 완료되었습니다! 🥳', 'success');
     } catch (error) {}
   };
 

--- a/src/pages/common/SignUp.tsx
+++ b/src/pages/common/SignUp.tsx
@@ -127,7 +127,6 @@ export const SignUp = () => {
         profileImg: '',
         tags: [],
       });
-      console.log('회원가입 및 Firestore 데이터 저장 성공:', user);
       toastTrigger('회원가입 완료!🥳 로그인 화면으로 돌아가 로그인해주세요.');
       setTimeout(() => {
         window.location.href = ROUTES.SIGN_IN;
@@ -148,7 +147,7 @@ export const SignUp = () => {
     const regex =
       /^(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{5,}$/;
     if (!regex.test(value)) {
-      return '비밀번호는 5자리 이상, 특수문자(!,@,-,$,*)포함이어야 합니다';
+      return '비밀번호는 6자리 이상, 특수문자(!,@,-,$,*)포함이어야 합니다';
     }
     return '사용 가능한 비밀번호입니다.';
   };
@@ -169,8 +168,8 @@ export const SignUp = () => {
 
   const isSignUpDisabled =
     id.length < 5 ||
-    password.length < 5 ||
-    passwordConfirm.length < 5 ||
+    password.length < 6 ||
+    passwordConfirm.length < 6 ||
     channelName.length < 2;
 
   return (

--- a/src/pages/common/SignUp.tsx
+++ b/src/pages/common/SignUp.tsx
@@ -127,6 +127,7 @@ export const SignUp = () => {
         tags: [],
       });
       console.log('회원가입 및 Firestore 데이터 저장 성공:', user);
+      window.location.reload();
       setIsSignUpSuccessToastActive(true);
     } catch (error) {
       console.error('회원가입 중 오류 발생:', error);

--- a/src/pages/common/SignUp.tsx
+++ b/src/pages/common/SignUp.tsx
@@ -170,7 +170,7 @@ export const SignUp = () => {
     channelName.length < 2;
 
   return (
-    <div>
+    <div css={containerStyle}>
       <Header type='detail' headerTitle='회원가입' />
       <form onSubmit={onSignUp} css={signUpContainerStyle}>
         <div css={duplicateStyle}>
@@ -261,6 +261,12 @@ export const SignUp = () => {
     </div>
   );
 };
+
+const containerStyle = css`
+  width: 100%;
+  max-width: 430px;
+  margin: 0 auto;
+`;
 
 const signUpContainerStyle = css`
   display: flex;

--- a/src/pages/common/SignUp.tsx
+++ b/src/pages/common/SignUp.tsx
@@ -65,6 +65,13 @@ export const SignUp = () => {
   };
 
   const onIdCheck = async () => {
+    const idValidationMessage = validateId(id);
+    if (idValidationMessage) {
+      setIdCheckMessage(idValidationMessage);
+      setIsIdChecked(false);
+      return;
+    }
+
     try {
       const idExists = await checkIdExists(id);
       if (idExists) {
@@ -78,6 +85,13 @@ export const SignUp = () => {
   };
 
   const onChannelNameCheck = async () => {
+    const channelNameValidation = validateChannelName(channelName);
+    if (channelNameValidation) {
+      setChannelNameCheckMessage(channelNameValidation);
+      setIsChannelNameChecked(false);
+      return;
+    }
+
     try {
       const exists = await checkChannelNameExists(channelName.trim());
       if (exists) {
@@ -95,7 +109,19 @@ export const SignUp = () => {
   ) => {
     setChannelName(e.target.value);
     setIsChannelNameChecked(false);
-    setChannelNameCheckMessage('다시 중복검사를 진행해주세요.');
+    setChannelNameCheckMessage(
+      e.target.value === '' ? '' : '다시 중복검사를 진행해주세요.'
+    );
+  };
+
+  const onIdChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setId(e.target.value);
+    setIsIdChecked(false);
+    setIdCheckMessage(
+      e.target.value === '' ? '' : '다시 중복검사를 진행해주세요.'
+    );
   };
 
   const onSignUp = async (e: React.FormEvent) => {
@@ -131,7 +157,7 @@ export const SignUp = () => {
         likedPlaylist: [],
         profileImg: '',
         tags: [],
-        isFirstLogin: false,
+        isFirstLogin: true,
       });
       navigate(ROUTES.SIGN_IN);
       toastTrigger('회원가입이 완료되었습니다! 🥳', 'success');
@@ -184,9 +210,7 @@ export const SignUp = () => {
             placeholder='아이디'
             value={id}
             validate={validateId}
-            onChange={(e) => {
-              setId(e.target.value);
-            }}
+            onChange={onIdChange}
             width='315px'
             externalErrorMessage={idCheckMessage}
           />

--- a/src/pages/common/SignUp.tsx
+++ b/src/pages/common/SignUp.tsx
@@ -55,7 +55,6 @@ export const SignUp = () => {
   };
 
   const checkIdExists = async (id: string): Promise<boolean> => {
-    const q = query(collection(db, 'users'), where('id', '==', id));
     try {
       const docRef = doc(db, 'users', id);
       const docSnap = await getDoc(docRef);
@@ -89,6 +88,14 @@ export const SignUp = () => {
         setIsChannelNameChecked(true);
       }
     } catch (error) {}
+  };
+
+  const onChannelNameChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setChannelName(e.target.value);
+    setIsChannelNameChecked(false);
+    setChannelNameCheckMessage('다시 중복검사를 진행해주세요.');
   };
 
   const onSignUp = async (e: React.FormEvent) => {
@@ -218,9 +225,7 @@ export const SignUp = () => {
             placeholder='채널 이름을 입력해주세요'
             value={channelName}
             validate={validateChannelName}
-            onChange={(e) => {
-              setChannelName(e.target.value);
-            }}
+            onChange={onChannelNameChange}
             width='315px'
             externalErrorMessage={channelNameCheckMessage}
           />

--- a/src/pages/common/SignUp.tsx
+++ b/src/pages/common/SignUp.tsx
@@ -14,7 +14,9 @@ import Button from '@/components/Button';
 import Header from '@/components/Header';
 import InputBox from '@/components/InputBox';
 import Toast from '@/components/Toast';
+import ROUTES from '@/constants/route';
 import { auth, db } from '@/firebase/firbaseConfig';
+import useToast from '@/hooks/useToast';
 
 export const SignUp = () => {
   const [id, setId] = useState<string>('');
@@ -29,9 +31,8 @@ export const SignUp = () => {
   const [isIdChecked, setIsIdChecked] = useState<boolean>(false);
   const [isChannelNameChecked, setIsChannelNameChecked] =
     useState<boolean>(false);
-  const [isToastActive, setIsToastActive] = useState<boolean>(false);
-  const [isSignUpSuccessToastActive, setIsSignUpSuccessToastActive] =
-    useState<boolean>(false);
+
+  const { toastTrigger } = useToast();
 
   const checkChannelNameExists = async (
     channelName: string
@@ -96,7 +97,7 @@ export const SignUp = () => {
     e.preventDefault();
 
     if (!isIdChecked || !isChannelNameChecked) {
-      setIsToastActive(true);
+      toastTrigger('중복 검사를 진행해주세요.');
       return;
     }
 
@@ -127,8 +128,10 @@ export const SignUp = () => {
         tags: [],
       });
       console.log('회원가입 및 Firestore 데이터 저장 성공:', user);
-      window.location.reload();
-      setIsSignUpSuccessToastActive(true);
+      toastTrigger('회원가입 완료!🥳 로그인 화면으로 돌아가 로그인해주세요.');
+      setTimeout(() => {
+        window.location.href = ROUTES.SIGN_IN;
+      }, 2000);
     } catch (error) {
       console.error('회원가입 중 오류 발생:', error);
     }
@@ -247,18 +250,7 @@ export const SignUp = () => {
           />
         </div>
       </form>
-      <Toast
-        isActive={isToastActive}
-        status='fail'
-        toastMsg='중복 검사를 진행해주세요.'
-        onClose={() => setIsToastActive(false)}
-      />
-      <Toast
-        isActive={isSignUpSuccessToastActive}
-        status='success'
-        toastMsg={`회원가입 완료!🥳 로그인 화면으로 돌아가 로그인해주세요.`}
-        onClose={() => setIsSignUpSuccessToastActive(false)}
-      />
+      <Toast />
     </div>
   );
 };

--- a/src/pages/common/SignUp.tsx
+++ b/src/pages/common/SignUp.tsx
@@ -46,7 +46,6 @@ export const SignUp = () => {
       const querySnapshot = await getDocs(q);
       return !querySnapshot.empty;
     } catch (error) {
-      console.error('채널 이름 중복 체크 오류:', error);
       throw new Error('중복 체크에 실패했습니다.');
     }
   };
@@ -58,7 +57,6 @@ export const SignUp = () => {
       const docSnap = await getDoc(docRef);
       return docSnap.exists();
     } catch (error) {
-      console.error('아이디 중복 체크 오류:', error);
       throw new Error('중복 체크에 실패했습니다.');
     }
   };
@@ -73,9 +71,7 @@ export const SignUp = () => {
         setIdCheckMessage('사용 가능한 아이디입니다.');
         setIsIdChecked(true);
       }
-    } catch (error) {
-      console.log('아이디 중복 검사 오류:', error);
-    }
+    } catch (error) {}
   };
 
   const onChannelNameCheck = async () => {
@@ -88,9 +84,7 @@ export const SignUp = () => {
         setChannelNameCheckMessage('사용 가능한 채널 이름입니다.');
         setIsChannelNameChecked(true);
       }
-    } catch (error) {
-      console.error('채널 이름 중복 검사 오류:', error);
-    }
+    } catch (error) {}
   };
 
   const onSignUp = async (e: React.FormEvent) => {
@@ -131,9 +125,7 @@ export const SignUp = () => {
       setTimeout(() => {
         window.location.href = ROUTES.SIGN_IN;
       }, 2000);
-    } catch (error) {
-      console.error('회원가입 중 오류 발생:', error);
-    }
+    } catch (error) {}
   };
 
   const validateId = (value: string) => {

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -6,6 +6,7 @@ import {
   query,
   where,
   getDocs,
+  updateDoc,
 } from 'firebase/firestore';
 import { create, StateCreator } from 'zustand';
 import { persist, PersistOptions } from 'zustand/middleware';
@@ -21,6 +22,7 @@ interface AuthState {
   channelFollower: string[];
   channelFollowing: string[];
   tags: string[];
+  isFirstLogin: boolean;
   setUser: (user: User | null) => void;
   clearUser: () => void;
   fetchUserData: (id: string) => void;
@@ -43,6 +45,7 @@ export const useAuthStore = create<AuthState>(
       channelFollower: [],
       channelFollowing: [],
       tags: [],
+      isFirstLogin: true,
 
       setUser: (user) => set({ user }),
       clearUser: () =>
@@ -64,6 +67,7 @@ export const useAuthStore = create<AuthState>(
             channelFollower: data?.channelFollower || [],
             channelFollowing: data?.channelFollowing || [],
             tags: data?.tags || [],
+            isFirstLogin: data?.isFirstLogin ?? true,
           });
         }
       },
@@ -85,6 +89,14 @@ export const useAuthStore = create<AuthState>(
     }
   )
 );
+
+export const updateFirstLogin = async (userId: string, tags: string[]) => {
+  const userDocRef = doc(db, 'users', userId);
+  await updateDoc(userDocRef, {
+    isFirstLogin: false,
+    tags,
+  });
+};
 
 onAuthStateChanged(auth, async (user) => {
   const { setUser, fetchUserData } = useAuthStore.getState();


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

회원가입 & 해시태그 페이지 기능 구현

## 📋 작업 내용

- 회원가입 레이아웃 수정
- 회원가입시 토스트 알림 뜨면서 로그인 페이지로 이동
- 최초 로그인시 해시태그 선택 -> Firestore users 컬렉션 Tags에 반영
- 토스트 useToast 이용하여 수정 