### PR TITLE
[feature] 플레이리스트 생성페이지 validation 기능 추가

### DIFF
--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -8,6 +8,8 @@ export const getVideoInfo = async (
   const { data } = await axios.get(`https://noembed.com/embed?url=${link}`);
   if (!!!data) return { status: 'fail' };
 
+  if (!!data.error) return { status: 'fail' };
+
   let videoId = '';
   if (data.provider_name === 'YouTube')
     videoId = data.thumbnail_url.split('/')[4];

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -6,17 +6,14 @@ import colors from '@/constants/colors';
 import { fontSize } from '@/constants/font';
 import useToast from '@/hooks/useToast';
 
-type ToastStatusType = 'success' | 'fail';
+export type ToastStatusType = 'success' | 'fail';
 
 interface ToastProps {
   duration?: number;
-  status?: ToastStatusType;
 }
 
-const Toast = ({ duration = 2000, status = 'success' }: ToastProps) => {
-  const { isToastOn, toastMsg, onClose } = useToast();
-  // const { toastMsg, onClose } = useToast();
-  // const isToastOn = true;
+const Toast = ({ duration = 2000 }: ToastProps) => {
+  const { isToastOn, toastMsg, onClose, status } = useToast();
 
   useEffect(() => {
     if (isToastOn) {

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -1,0 +1,4 @@
+export const Regex = {
+  youtube:
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]+)/i,
+};

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,11 +1,12 @@
+import { ToastStatusType } from '@/components/Toast';
 import { useToastStore } from '@/stores/useToastStore';
 
 const useToast = () => {
-  const { isToastOn, toastMsg, toastOn, toastOff } = useToastStore();
+  const { isToastOn, toastMsg, toastOn, toastOff, status } = useToastStore();
 
   const handler = {
-    toastTrigger: (msg: string) => {
-      toastOn(msg);
+    toastTrigger: (msg: string, status: ToastStatusType = 'success') => {
+      toastOn(msg, status);
     },
     onClose: () => {
       toastOff();
@@ -15,6 +16,7 @@ const useToast = () => {
   return {
     isToastOn,
     toastMsg,
+    status,
     toastTrigger: handler.toastTrigger,
     onClose: handler.onClose,
   };

--- a/src/pages/playlist/PlayListAdd.tsx
+++ b/src/pages/playlist/PlayListAdd.tsx
@@ -35,7 +35,7 @@ const TEXT = {
   link: {
     label: '영상 링크 추가',
     placeholder: '영상 링크를 입력해주세요.',
-    validmsg: '지원하지 않는 링크 형식입니다.',
+    validmsg: '지원하지 않는 영상입니다.',
     validDuplmsg: '중복된 링크입니다.',
     required: '영상링크를 1개이상 입력해주세요.',
   },
@@ -102,7 +102,7 @@ const PlayListAdd = () => {
     INIT_VALUES.preview
   );
 
-  const { user, channelName } = useAuthStore();
+  const { userId, channelName } = useAuthStore();
   const { toastTrigger } = useToast();
   const navigate = useNavigate();
 
@@ -157,7 +157,7 @@ const PlayListAdd = () => {
     createPreview: () => {
       setPreview({
         title,
-        userId: user?.uid ?? '',
+        userId: userId ?? '',
         tags: addedHashtag.map((tag) => tag.label),
         likes: 0,
         description: desc,
@@ -180,7 +180,11 @@ const PlayListAdd = () => {
         return;
       }
       const { status, result } = await getVideoInfo(link);
-      if (status === 'fail' || !!!result) return;
+      console.log(status, result);
+      if (status === 'fail' || !!!result) {
+        toastTrigger(TEXT.link.validmsg);
+        return;
+      }
 
       setVideoList([...videoList, result]);
       setLink('');
@@ -228,7 +232,7 @@ const PlayListAdd = () => {
 
       if (response.status === 'success') {
         toastTrigger(TEXT.toast.success);
-        navigate(ROUTES.PLAYLIST(user?.uid));
+        navigate(ROUTES.PLAYLIST(userId));
       }
     },
   };

--- a/src/pages/playlist/PlayListAdd.tsx
+++ b/src/pages/playlist/PlayListAdd.tsx
@@ -22,6 +22,7 @@ import { tagging } from '@/utils/textUtils';
 import { getVideoId } from '@/utils/videoUtils';
 
 const TEXT = {
+  toggle: { active: '공개', inactive: '비공개' },
   title: {
     label: '플레이리스트 제목',
     placeholder: '플레이리스트 제목을 입력해주세요.',
@@ -46,8 +47,15 @@ const TEXT = {
     limit: '해시태그는 5개까지 등록할 수 있습니다.',
     validDuplmsg: '중복된 해시태그입니다.',
   },
+  thumbnail: {
+    label: '썸네일',
+    desc: '플레이리스트 메인 썸네일을 선택해주세요.',
+  },
+  preview: {
+    large: '미리보기 (large)',
+    small: '미리보기 (small)',
+  },
   createButton: { label: '플레이리스트 생성하기', loading: '생성 중...' },
-  toggle: { active: '공개', inactive: '비공개' },
   toast: { success: '플레이리스트 생성이 완료되었습니다.' },
 };
 
@@ -125,7 +133,7 @@ const PlayListAdd = () => {
       return '';
     },
     hashtag: (value: string) => {
-      if (value.trim().length < 1) {
+      if (value.trim().length < 1 || value.trim() === '#') {
         toastTrigger(TEXT.hashtag.required);
         return false;
       }
@@ -205,6 +213,12 @@ const PlayListAdd = () => {
       setAddedHashtag(addedHashtag.filter((tag) => tag.id !== id));
     },
     createPlaylist: async () => {
+      const checkResult = check.required();
+      if (!!!checkResult.status) {
+        toastTrigger(checkResult.msg);
+        return;
+      }
+
       const playlist: PlayListDataProps = {
         ...preview,
         thumbnailFile: thumbnail?.file,
@@ -220,6 +234,22 @@ const PlayListAdd = () => {
   };
 
   const check = {
+    required: (): {
+      status: boolean;
+      msg: string;
+    } => {
+      if (title.trim().length < 1)
+        return { status: false, msg: TEXT.title.required };
+      if (videoList.length < 1)
+        return { status: false, msg: TEXT.link.required };
+      if (addedHashtag.length < 1)
+        return {
+          status: false,
+          msg: TEXT.hashtag.required,
+        };
+
+      return { status: true, msg: '' };
+    },
     dupl: {
       hashtag: (inputTag: string): boolean => {
         let result = false;
@@ -341,11 +371,11 @@ const PlayListAdd = () => {
         <HashTag onRemove={onClick.removeHashtag} tags={addedHashtag} />
       </div>
       <div css={thumbnailStyle}>
-        <label style={labelStyle}>썸네일</label>
+        <label style={labelStyle}>{TEXT.thumbnail.label}</label>
         <label
           style={{ fontSize: `${fontSize.sm}`, color: `${colors.gray04}` }}
         >
-          플레이리스트 메인 썸네일을 선택해주세요.
+          {TEXT.thumbnail.desc}
         </label>
 
         <Button
@@ -378,9 +408,9 @@ const PlayListAdd = () => {
         )}
       </div>
       <div css={previewStyle}>
-        <label style={labelStyle}>미리보기(large)</label>
+        <label style={labelStyle}>{TEXT.preview.large}</label>
         <PlaylistCard playlistItem={preview} size='large' />
-        <label style={labelStyle}>미리보기(small)</label>
+        <label style={labelStyle}>{TEXT.preview.small}</label>
         <PlaylistCard playlistItem={preview} size='small' />
       </div>
 

--- a/src/pages/playlist/PlayListAdd.tsx
+++ b/src/pages/playlist/PlayListAdd.tsx
@@ -42,6 +42,9 @@ const TEXT = {
     label: '해시태그',
     desc: '최대 5개까지 입력 가능합니다.',
     placeholder: '#',
+    required: '해시태그를 입력해주세요',
+    limit: '해시태그는 5개까지 등록할 수 있습니다.',
+    validDuplmsg: '중복된 해시태그입니다.',
   },
   createButton: { label: '플레이리스트 생성하기', loading: '생성 중...' },
   toggle: { active: '공개', inactive: '비공개' },
@@ -106,20 +109,13 @@ const PlayListAdd = () => {
 
   const onKeydown = {
     link: (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (validation.link(link)) {
-        return;
-      }
       if (e.key === 'Enter') onClick.addVideoLink();
     },
     hashtag: (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // 입력 valid 체크
-      // const valid = validation.hashtag;
-      // if (e.key === ' ') console.log('a');
       if (e.key === 'Enter') onClick.addHashtag();
     },
   };
 
-  // true: 조건에 걸림, false: 통과
   const validation = {
     link: (value: string) => {
       if (!Regex.youtube.test(value)) return TEXT.link.validmsg;
@@ -128,13 +124,22 @@ const PlayListAdd = () => {
       if (videoId && check.dupl.link(videoId)) return TEXT.link.validDuplmsg;
       return '';
     },
-    // duplLink: (videoId: string) => {
-    //   let result = false;
-    //   videoList.map((video) => {
-    //     if (video.videoId === videoId) return (result = true);
-    //   });
-    //   return result;
-    // },
+    hashtag: (value: string) => {
+      if (value.trim().length < 1) {
+        toastTrigger(TEXT.hashtag.required);
+        return false;
+      }
+      if (addedHashtag.length >= 5) {
+        toastTrigger(TEXT.hashtag.limit);
+        return false;
+      }
+      const taggedValue = tagging(value);
+      if (check.dupl.hashtag(taggedValue)) {
+        toastTrigger(TEXT.hashtag.validDuplmsg);
+        return false;
+      }
+      return true;
+    },
   };
 
   const methods = {
@@ -180,6 +185,7 @@ const PlayListAdd = () => {
       if (fileInputRef.current) fileInputRef.current.value = '';
     },
     addHashtag: () => {
+      if (!!!validation.hashtag(hashtag)) return;
       const taggedValue = tagging(hashtag);
 
       setAddedHashtag([
@@ -215,6 +221,14 @@ const PlayListAdd = () => {
 
   const check = {
     dupl: {
+      hashtag: (inputTag: string): boolean => {
+        let result = false;
+
+        addedHashtag.map((hashtag) => {
+          if (hashtag.label === inputTag) return (result = true);
+        });
+        return result;
+      },
       link: (videoId: string): boolean => {
         let result = false;
         videoList.map((video) => {

--- a/src/pages/playlist/PlayListAdd.tsx
+++ b/src/pages/playlist/PlayListAdd.tsx
@@ -134,16 +134,16 @@ const PlayListAdd = () => {
     },
     hashtag: (value: string) => {
       if (value.trim().length < 1 || value.trim() === '#') {
-        toastTrigger(TEXT.hashtag.required);
+        toastTrigger(TEXT.hashtag.required, 'fail');
         return false;
       }
       if (addedHashtag.length >= 5) {
-        toastTrigger(TEXT.hashtag.limit);
+        toastTrigger(TEXT.hashtag.limit, 'fail');
         return false;
       }
       const taggedValue = tagging(value);
       if (check.dupl.hashtag(taggedValue)) {
-        toastTrigger(TEXT.hashtag.validDuplmsg);
+        toastTrigger(TEXT.hashtag.validDuplmsg, 'fail');
         return false;
       }
       return true;
@@ -180,9 +180,8 @@ const PlayListAdd = () => {
         return;
       }
       const { status, result } = await getVideoInfo(link);
-      console.log(status, result);
       if (status === 'fail' || !!!result) {
-        toastTrigger(TEXT.link.validmsg);
+        toastTrigger(TEXT.link.validmsg, 'fail');
         return;
       }
 
@@ -219,7 +218,7 @@ const PlayListAdd = () => {
     createPlaylist: async () => {
       const checkResult = check.required();
       if (!!!checkResult.status) {
-        toastTrigger(checkResult.msg);
+        toastTrigger(checkResult.msg, 'fail');
         return;
       }
 

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -1,20 +1,23 @@
 import { create } from 'zustand';
+import { ToastStatusType } from '@/components/Toast';
 
 interface ToastState {
   isToastOn: boolean;
+  status: ToastStatusType;
   toastMsg: string;
-  toastOn: (msg: string) => void;
+  toastOn: (msg: string, status?: ToastStatusType) => void;
   toastOff: () => void;
 }
 
 export const useToastStore = create<ToastState>((set) => ({
   isToastOn: false,
   toastMsg: '',
+  status: 'success',
 
-  toastOn: (msg: string) => {
-    set({ isToastOn: true, toastMsg: msg });
+  toastOn: (msg: string, status: ToastStatusType = 'success') => {
+    set({ isToastOn: true, toastMsg: msg, status });
   },
   toastOff: () => {
-    set({ isToastOn: false, toastMsg: '' });
+    set({ isToastOn: false, toastMsg: '', status: 'success' });
   },
 }));

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -4,6 +4,7 @@ export const omittedText = (
   value: string,
   maxLength: number = DEFAULT_MAX_LENGTH
 ): string => {
+  if (!!!value || value.trim().length < 1) return '';
   if (value.length > maxLength)
     return value.trim().substring(0, maxLength) + '...';
 

--- a/src/utils/videoUtils.ts
+++ b/src/utils/videoUtils.ts
@@ -1,14 +1,10 @@
+import { Regex } from '@/constants/validation';
+
 const example = [
   'https://www.youtube.com/watch?v=MvbWDw8mWAY&ab_channel=%EB%AA%BD%ED%82%A4%EB%A7%A4%EC%A7%81%EA%B2%8C%EC%9E%84%EC%B1%84%EB%84%90',
   'https://youtu.be/MvbWDw8mWAY?si=qU9NoablEFldSib6',
   'https://www.youtube.com/embed/MvbWDw8mWAY?si=qU9NoablEFldSib6',
 ];
-
-const Regex: Record<string, RegExp> = {
-  // youtube: /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\//i,
-  youtube:
-    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]+)/i,
-};
 
 export interface MethodResult<T> {
   status: 'success' | 'fail';
@@ -29,8 +25,8 @@ const getLinkType = (link: string): LinkType => {
   return 'vimeo';
 };
 
-const getVideoId = (link: string, type: LinkType) => {
-  const videoId = link.match(Regex[type])?.[1];
+export const getVideoId = (link: string, type: LinkType = 'youtube') => {
+  const videoId = link.match(Regex.youtube)?.[1];
   // if (!!!videoId) return { status: 'fail' };
   return videoId;
 };

--- a/src/utils/videoUtils.ts
+++ b/src/utils/videoUtils.ts
@@ -1,9 +1,9 @@
 import { Regex } from '@/constants/validation';
 
 const example = [
-  'https://www.youtube.com/watch?v=MvbWDw8mWAY&ab_channel=%EB%AA%BD%ED%82%A4%EB%A7%A4%EC%A7%81%EA%B2%8C%EC%9E%84%EC%B1%84%EB%84%90',
-  'https://youtu.be/MvbWDw8mWAY?si=qU9NoablEFldSib6',
-  'https://www.youtube.com/embed/MvbWDw8mWAY?si=qU9NoablEFldSib6',
+  'https://www.youtube.com/watch?v=n6B5gQXlB-0&ab_channel=HYBELABELS',
+  'https://youtu.be/n6B5gQXlB-0?si=k1ddkQxbXNPD7_ph',
+  'https://www.youtube.com/embed/n6B5gQXlB-0?si=k1ddkQxbXNPD7_ph',
 ];
 
 export interface MethodResult<T> {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

플레이리스트 생성페이지 validation 기능 추가
closes #113 

## 📋 작업 내용

- 제목, 링크, 해시태그에 대한 필수값 확인
- 변환 가능한 링크에 대한 validation
- 링크 변환 실패시 표시
- 해시태그 중복체크, 최대 5개까지 등록가능하도록 validation

## 🔧 변경 사항

- Toast에 아이콘을 지정할 수 있게 변경되었습니다.
- ToastTrigger(msg, 'success' | 'fail') 처럼 호출해 토스트에 표시되는 아이콘을 변경할 수 있습니다.
- 기본값은 success이므로 기존코드는 변경하지 않아도 정상작동 합니다.

## 📸 스크린샷 (선택 사항)

#### 필수값 입력 안되어있을 경우
![스크린샷 2024-09-04 105522](https://github.com/user-attachments/assets/5021562d-dd86-4392-b23a-297b5fd81ec8)

#### 지원하지않는 영상링크의 경우
![image](https://github.com/user-attachments/assets/65b986c5-1d97-409d-b190-99034f3a1925)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
