### PR TITLE
[feature] 마이플리 페이지 개발

### DIFF
--- a/src/api/chennelInfo.ts
+++ b/src/api/chennelInfo.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect, useCallback } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { useParams } from 'react-router-dom';
+import { db } from '@/firebase/firbaseConfig';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+interface ChennelDataProps {
+  channelFollower: string[];
+  channelFollowing: string[];
+  channelName: string;
+  profileImg: string;
+  isMyChannel: boolean;
+}
+
+export const useChennelData = (userId: string | undefined) => {
+  const [chennelData, setChennelData] = useState<ChennelDataProps | null>(null);
+  const { userId: loggedInUserId } = useAuthStore();
+  const { userId: channelOwnerId } = useParams<{ userId: string }>();
+
+  const fetchChennelData = useCallback(() => {
+    if (!userId) {
+      setChennelData(null);
+      return () => {};
+    }
+
+    const userDocRef = doc(db, 'users', userId);
+
+    const unsubscribe = onSnapshot(
+      userDocRef,
+      (docSnapshot) => {
+        if (docSnapshot.exists()) {
+          const data = docSnapshot.data();
+          const selectedData: ChennelDataProps = {
+            channelFollower: data.channelFollower || [],
+            channelFollowing: data.channelFollowing || [],
+            channelName: data.channelName || '',
+            profileImg: data.profileImg || '',
+            isMyChannel: loggedInUserId === channelOwnerId,
+          };
+          setChennelData(selectedData);
+        } else {
+          setChennelData(null);
+        }
+      },
+      (error) => {
+        console.error(
+          '사용자 데이터를 가져오는 동안 오류가 발생했습니다:',
+          error
+        );
+        setChennelData(null);
+      }
+    );
+
+    return unsubscribe;
+  }, [userId, loggedInUserId, channelOwnerId]);
+
+  useEffect(() => {
+    const unsubscribe = fetchChennelData();
+    return () => {
+      if (unsubscribe) unsubscribe();
+    };
+  }, [fetchChennelData]);
+
+  return { chennelData, refetchChennelData: fetchChennelData };
+};

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -28,14 +28,21 @@ const Navbar: React.FC = () => {
   return (
     <nav css={navbarStyle}>
       {navList.map((list, idx) => {
-        const isActive =
-          list.to === ROUTES.ROOT
-            ? location.pathname === list.to
-            : location.pathname.startsWith(list.to);
+        let isActive = false;
+
+        if (list.to === ROUTES.ROOT) {
+          isActive = location.pathname === list.to;
+        } else if (list.label === '마이플리') {
+          const playlistBaseRoute = '/playlist';
+          isActive = location.pathname.startsWith(playlistBaseRoute);
+        } else {
+          isActive = location.pathname.startsWith(list.to);
+        }
 
         const onClick = () => {
           if (list.label === '마이플리' && userId) {
-            navigate(ROUTES.PLAYLIST(userId));
+            const route = `/playlist/${userId}`;
+            navigate(route);
           } else {
             navigate(list.to);
           }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -41,8 +41,7 @@ const Navbar: React.FC = () => {
 
         const onClick = () => {
           if (list.label === '마이플리' && userId) {
-            const route = `/playlist/${userId}`;
-            navigate(route);
+            navigate(ROUTES.PLAYLIST(userId));
           } else {
             navigate(list.to);
           }

--- a/src/hooks/useFollowToggle.ts
+++ b/src/hooks/useFollowToggle.ts
@@ -1,0 +1,96 @@
+import { useCallback, useState, useEffect } from 'react';
+import {
+  doc,
+  updateDoc,
+  arrayUnion,
+  arrayRemove,
+  getDoc,
+  setDoc,
+} from 'firebase/firestore';
+import { useChennelData } from '@/api/chennelInfo';
+import { db } from '@/firebase/firbaseConfig';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+interface UserDataProps {
+  channelFollower: string[];
+  channelFollowing: string[];
+  channelName: string;
+  profileImg: string;
+  uid: string;
+}
+
+export const useFollowToggle = (userId: string | undefined) => {
+  const { user, fetchUserData } = useAuthStore();
+  const { chennelData } = useChennelData(userId);
+  const [isFollowing, setIsFollowing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (chennelData && user) {
+      setIsFollowing(chennelData.channelFollower.includes(user.uid));
+    }
+  }, [chennelData, user]);
+
+  const createDefaultUserDoc = (uid: string): UserDataProps => ({
+    channelFollower: [],
+    channelFollowing: [],
+    channelName: '',
+    profileImg: '',
+    uid,
+  });
+
+  const handleFollowToggle = useCallback(async () => {
+    if (!user || !userId) {
+      setError('User information is missing');
+      return;
+    }
+
+    setError(null);
+    const channelRef = doc(db, 'users', userId);
+    const currentUserRef = doc(db, 'users', user.uid);
+
+    try {
+      const [channelDoc, currentUserDoc] = await Promise.all([
+        getDoc(channelRef),
+        getDoc(currentUserRef),
+      ]);
+
+      if (!channelDoc.exists()) {
+        await setDoc(channelRef, createDefaultUserDoc(userId));
+      }
+      if (!currentUserDoc.exists()) {
+        await setDoc(currentUserRef, createDefaultUserDoc(user.uid));
+      }
+
+      if (isFollowing) {
+        // 팔로우 취소
+        await updateDoc(channelRef, {
+          channelFollower: arrayRemove(user.uid),
+        });
+        await updateDoc(currentUserRef, {
+          channelFollowing: arrayRemove(userId),
+        });
+      } else {
+        // 팔로우
+        await updateDoc(channelRef, {
+          channelFollower: arrayUnion(user.uid),
+        });
+        await updateDoc(currentUserRef, {
+          channelFollowing: arrayUnion(userId),
+        });
+      }
+
+      setIsFollowing(!isFollowing);
+
+      await fetchUserData(user.uid);
+    } catch (error) {
+      console.error(
+        '팔로우 상태를 업데이트하는 동안 오류가 발생했습니다:',
+        error
+      );
+      setError('팔로우 상태를 업데이트하지 못했습니다. 다시 시도해 주세요.');
+    }
+  }, [isFollowing, user, userId, fetchUserData]);
+
+  return { isFollowing, handleFollowToggle, error };
+};

--- a/src/pages/playlist/PlayListHome.tsx
+++ b/src/pages/playlist/PlayListHome.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import { Plus } from 'lucide-react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import { useChennelData } from '@/api/chennelInfo';
 import { useFetchUserPlaylist } from '@/api/myplaylists';
 import Button from '@/components/Button';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -20,6 +21,9 @@ const PAGE_SIZE = 5;
 
 export const PlayListHome = () => {
   const navigate = useNavigate();
+  const { userId } = useParams<{ userId: string }>();
+  const { chennelData } = useChennelData(userId);
+
   const [filterOptions, setFilterOptions] = useState<number[]>([0, 0]);
 
   const optionGroups = [
@@ -58,7 +62,7 @@ export const PlayListHome = () => {
   }, [playlist, filterOptions]);
 
   const onAddBtnClick = (): void => {
-    navigate(ROUTES.PLAYLIST_ADD());
+    navigate(ROUTES.PLAYLIST_ADD(userId));
   };
 
   return (
@@ -69,12 +73,14 @@ export const PlayListHome = () => {
           selectedIndexes={filterOptions}
           setSelectedIndexes={setFilterOptions}
         />
-        <Button
-          label='플레이리스트 생성'
-          IconComponent={Plus}
-          shape='text'
-          onClick={onAddBtnClick}
-        />
+        {chennelData?.isMyChannel && (
+          <Button
+            label='플레이리스트 생성'
+            IconComponent={Plus}
+            shape='text'
+            onClick={onAddBtnClick}
+          />
+        )}
       </div>
       {filteredPlaylist.length > 0 && (
         <p>총 {filteredPlaylist.length}개의 플리</p>
@@ -94,8 +100,8 @@ export const PlayListHome = () => {
               <PlaylistCard
                 size='small'
                 playlistItem={playlistItem}
-                showLockButton={true}
-                showKebabMenu={true}
+                showLockButton={chennelData?.isMyChannel ? true : false}
+                showKebabMenu={chennelData?.isMyChannel ? true : false}
               />
             </li>
           ))}
@@ -123,7 +129,7 @@ const homeContainerStyles = css`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 12px 20px;
+  padding: 12px 20px 0 20px;
   height: calc(100% - ${profileHeight} - ${tabHeight});
 
   .filter-area {

--- a/src/pages/playlist/PlayListLikes.tsx
+++ b/src/pages/playlist/PlayListLikes.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import { Plus } from 'lucide-react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import { useChennelData } from '@/api/chennelInfo';
 import { useFetchLikedPlaylist } from '@/api/myplaylists';
 import Button from '@/components/Button';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -17,6 +18,9 @@ const PAGE_SIZE = 5;
 
 export const PlayListLikes = () => {
   const navigate = useNavigate();
+  const { userId } = useParams<{ userId: string }>();
+  const { chennelData } = useChennelData(userId);
+
   const [filterOptions, setFilterOptions] = useState<number[]>([0]);
 
   const optionGroups = [
@@ -67,12 +71,14 @@ export const PlayListLikes = () => {
             selectedIndexes={filterOptions}
             setSelectedIndexes={setFilterOptions}
           />
-          <Button
-            label='플레이리스트 생성'
-            IconComponent={Plus}
-            shape='text'
-            onClick={onAddBtnClick}
-          />
+          {chennelData?.isMyChannel && (
+            <Button
+              label='플레이리스트 생성'
+              IconComponent={Plus}
+              shape='text'
+              onClick={onAddBtnClick}
+            />
+          )}
         </div>
         {sortedPlaylist.length > 0 && (
           <p>총 {sortedPlaylist.length}개의 플리</p>
@@ -122,7 +128,7 @@ const homeContainerStyles = css`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 12px 20px;
+  padding: 12px 20px 0 20px;
   height: calc(100% - ${profileHeight} - ${tabHeight});
 
   .filter-area {

--- a/src/pages/playlist/PlayListSaved.tsx
+++ b/src/pages/playlist/PlayListSaved.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import { Plus } from 'lucide-react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import { useChennelData } from '@/api/chennelInfo';
 import { useFetchSavedPlaylist } from '@/api/myplaylists';
 import Button from '@/components/Button';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -17,6 +18,9 @@ const PAGE_SIZE = 5;
 
 export const PlayListSaved = () => {
   const navigate = useNavigate();
+  const { userId } = useParams<{ userId: string }>();
+  const { chennelData } = useChennelData(userId);
+
   const [filterOptions, setFilterOptions] = useState<number[]>([0]);
 
   const optionGroups = [
@@ -51,7 +55,7 @@ export const PlayListSaved = () => {
   );
 
   const onAddBtnClick = (): void => {
-    navigate(ROUTES.PLAYLIST_ADD());
+    navigate(ROUTES.PLAYLIST_ADD(userId));
   };
 
   const onPopularBtnClick = (): void => {
@@ -67,12 +71,14 @@ export const PlayListSaved = () => {
             selectedIndexes={filterOptions}
             setSelectedIndexes={setFilterOptions}
           />
-          <Button
-            label='플레이리스트 생성'
-            IconComponent={Plus}
-            shape='text'
-            onClick={onAddBtnClick}
-          />
+          {chennelData?.isMyChannel && (
+            <Button
+              label='플레이리스트 생성'
+              IconComponent={Plus}
+              shape='text'
+              onClick={onAddBtnClick}
+            />
+          )}
         </div>
         {sortedPlaylist.length > 0 && (
           <p>총 {sortedPlaylist.length}개의 플리</p>
@@ -93,7 +99,7 @@ export const PlayListSaved = () => {
                 <PlaylistCard
                   size='small'
                   playlistItem={playlistItem}
-                  showAddButton={true}
+                  showAddButton={chennelData?.isMyChannel ? true : false}
                 />
               </li>
             ))}
@@ -122,7 +128,7 @@ const homeContainerStyles = css`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 12px 20px;
+  padding: 12px 20px 0 20px;
   height: calc(100% - ${profileHeight} - ${tabHeight});
 
   .filter-area {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

마이플리 페이지 개발

## 📋 작업 내용
**[팔로워, 팔로잉]**
- 버튼 클릭 시 라우팅 처리
- useFollowToggle을 통해 팔로우 토글 실시간 업데이트 처리
- 영상상세페이지에서 useFollowToggle 사용시 useFollowToggle에 해당 영상 채널주인의 userId값을 전해주면 됩니다.

**[채널관련정보]**
- 채널관련 정보 불러오기(팔로워/팔로잉 수, 채널명, 이미지). useChennelData를 통해 url의 userID와 users 테이블의 문서명이 일치하는 유저정보를 불러옵니다

**[자기 채널이 아닌경우]**
- 좋아요 탭 숨기기
- 플레이리스트 생성버튼 숨기기
- 카드의 정보뻬고 동작버튼 숨기기

**[자기 채널인 경우]**
- 팔로잉 버튼 숨기기
- 플레이리스트 추가 눌렀을때 url userId 변경

**[마이플리 Navbar 활성화 안되는 문제 해결]**
- 나브바에서 마이플리 활성화 안되는 문제 해결 & 플레이리스트 추가시에도 마이플리 탭 활성화 되도록 수정
- /playlist'로 시작하는 모든 경로에 대해 '마이플리' 항목이 활성화되도록 수정



