### PR TITLE
[test] 로그인 페이지 테스트 코드 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist
 dist-ssr
 *.local
 
+.last-run.json
+
 #firebase config data
 .env
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,6 +10,6 @@ export default defineConfig({
   reporter: 'list',
   use: {
     ...devices['Desktop Chrome'],
-    baseURL: 'http://localhost:5173', // 여기에 실제 개발 서버 URL을 입력하세요
+    baseURL: 'http://localhost:5173',
   },
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,15 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './src/tests',
+  timeout: 30000,
+  expect: {
+    timeout: 5000,
+  },
+  fullyParallel: true,
+  reporter: 'list',
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: 'http://localhost:5173', // 여기에 실제 개발 서버 URL을 입력하세요
+  },
+});

--- a/src/tests/signIn.spec.js
+++ b/src/tests/signIn.spec.js
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+
+const TEST_USER_ID = 'test1234';
+const TEST_PASSWORD = 'test1234';
+
+test.describe('로그인 페이지', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/signin');
+  });
+
+  test('로그인 폼이 올바르게 렌더링되는지 테스트', async ({ page }) => {
+    await expect(page.getByAltText('위플리 로고')).toBeVisible();
+    await expect(page.getByPlaceholder('아이디')).toBeVisible();
+    await expect(page.getByPlaceholder('비밀번호')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: '로그인', exact: true })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /구글로 로그인/i })
+    ).toBeVisible();
+    await expect(page.getByText('계정이 없으신가요?')).toBeVisible();
+    await expect(page.getByText('회원가입하기')).toBeVisible();
+  });
+
+  test('필드가 비어있을 때 로그인 버튼이 비활성화되는지 테스트', async ({
+    page,
+  }) => {
+    const loginButton = page.getByRole('button', {
+      name: '로그인',
+      exact: true,
+    });
+    await expect(loginButton).toBeDisabled();
+  });
+
+  test('필드가 채워졌을 때 로그인 버튼이 활성화되는지 테스트', async ({
+    page,
+  }) => {
+    await page.getByPlaceholder('아이디').fill(TEST_USER_ID);
+    await page.getByPlaceholder('비밀번호').fill(TEST_PASSWORD);
+    const loginButton = page.getByRole('button', {
+      name: '로그인',
+      exact: true,
+    });
+    await expect(loginButton).toBeEnabled();
+  });
+
+  test('잘못된 로그인 시도 시 에러 메시지가 표시되는지 테스트', async ({
+    page,
+  }) => {
+    await page.getByPlaceholder('아이디').fill('invaliduser');
+    await page.getByPlaceholder('비밀번호').fill('wrongpassword');
+    await page.getByRole('button', { name: '로그인', exact: true }).click();
+    await expect(
+      page.getByText('아이디와 비밀번호를 확인해주세요')
+    ).toBeVisible();
+  });
+
+  test('회원가입하기 링크 클릭 시 회원가입 페이지로 이동하는지 테스트', async ({
+    page,
+  }) => {
+    await page.getByText('회원가입하기').click();
+    await expect(page).toHaveURL(/.*\/signup/);
+  });
+
+  test('Google 로그인 버튼 클릭이 정상적으로 작동하는지 테스트', async ({
+    page,
+  }) => {
+    const googleLoginButton = page.getByRole('button', {
+      name: /구글로 로그인/i,
+    });
+    await googleLoginButton.click();
+  });
+});


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

로그인 페이지 테스트 코드 작성

## 📋 작업 내용
**다음과 같은 내용을 테스트합니다. 6개의 항목 success**
1. 로그인 폼이 올바르게 렌더링되는지 테스트
2. 필드가 비어있을 때 로그인 버튼이 비활성화되는지 테스트
3. 필드가 채워졌을 때 로그인 버튼이 활성화되는지 테스트
4. 잘못된 로그인 시도 시 에러 메시지가 표시되는지 테스트
5. 회원가입하기 링크 클릭 시 회원가입 페이지로 이동하는지 테스트
6. Google 로그인 버튼 클릭이 정상적으로 작동하는지 테스트


## 🔧 테스트
- 크롬환경에서 테스트 해야합니다.
- localhost:5173로 접속해야 합니다.
- 터미널에 **npx playwright test** 명령어를 입력하여 실행합니다.

## 📸 스크린샷 (선택 사항)
**테스트용 파일**은 이 곳에서 관리합니다.
<img width="206" alt="스크린샷 2024-09-06 오후 11 19 11" src="https://github.com/user-attachments/assets/237d4af9-40ea-456b-9fc2-61d3e4f0d921">

**테스트 실행 기록 및 실패 추적 파일**(.gitignore에 저장)
<img width="177" alt="스크린샷 2024-09-06 오후 11 19 38" src="https://github.com/user-attachments/assets/4ab9c18d-837d-472e-a661-e27635754e0f">

