### PR TITLE
[feature] 프로필 수정 페이지 UI 퍼블리싱 & 기능구현

### DIFF
--- a/src/api/profileInfo.ts
+++ b/src/api/profileInfo.ts
@@ -53,6 +53,23 @@ const getMyPlaylistCount = async (userId: string) => {
   }
 };
 
+const getMyHashtag = async (userId: string) => {
+  const userDoc = doc(db, 'users', userId);
+  const userSnapshot = await getDoc(userDoc);
+  if (userSnapshot.exists()) {
+    const userData = userSnapshot.data();
+    const hashtags = userData.tags;
+    return hashtags;
+  }
+};
+
+const updateProfileTags = async (userId: string, tags: string[]) => {
+  const userDoc = doc(db, 'users', userId);
+  await updateDoc(userDoc, {
+    tags,
+  });
+};
+
 const uploadImage = async (file: File, userId: string) => {
   const path = `profile/${userId}/${file.name}`;
   const locationRef = ref(storage, path);
@@ -80,4 +97,6 @@ export {
   getPlaylistTitle,
   getMyPlaylistCount,
   updateProfileImage,
+  getMyHashtag,
+  updateProfileTags,
 };

--- a/src/components/HashTag.tsx
+++ b/src/components/HashTag.tsx
@@ -49,6 +49,7 @@ const HashTag: React.FC<TagProps> = ({
               css={removeButtonStyle}
               onClick={(e) => {
                 e.stopPropagation();
+                e.preventDefault();
                 onRemove(tag.label);
               }}
             >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,7 @@ import colors from '@/constants/colors';
 import { fontSize, fontWeight } from '@/constants/font';
 import ROUTES from '@/constants/route';
 import { useAuthStore } from '@/stores/useAuthStore';
+import useModalStore from '@/stores/useModalStore';
 import { HeaderProps } from '@/types/header';
 
 const Header: React.FC<HeaderProps> = ({ type, headerTitle }) => {
@@ -18,6 +19,7 @@ const Header: React.FC<HeaderProps> = ({ type, headerTitle }) => {
   const { keyword } = useParams<{ keyword?: string }>();
   const navigate = useNavigate();
   const location = useLocation();
+  const { openModal, closeModal } = useModalStore();
 
   useEffect(() => {
     if (location.pathname.startsWith('/search/') && keyword) {
@@ -42,12 +44,28 @@ const Header: React.FC<HeaderProps> = ({ type, headerTitle }) => {
     }
   };
 
+  const onModifyBackButton = () => {
+    if (headerTitle === '프로필 수정') {
+      openModal({
+        type: 'confirm',
+        title: '알림',
+        content: '프로필 변경사항을 적용하지 않으시겠습니까?',
+        onAction: () => {
+          closeModal();
+          navigate(-1);
+        },
+      });
+    } else {
+      navigate(-1);
+    }
+  };
+
   return (
     <header css={headerStyle}>
       {type === 'main' ? (
         <Logo logoWidth={100} clickable={true} />
       ) : (
-        <IconButton IconComponent={ChevronLeft} onClick={() => navigate(-1)} />
+        <IconButton IconComponent={ChevronLeft} onClick={onModifyBackButton} />
       )}
       {type !== 'detail' ? (
         <>

--- a/src/hooks/useCheckDuplicate.ts
+++ b/src/hooks/useCheckDuplicate.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+export const useCheckDuplicate = () => {
+  const [message, setMessage] = useState('');
+  const [isChecked, setIsChecked] = useState(false);
+
+  const checkDuplicate = async (
+    value: string,
+    checkFunc: (val: string) => Promise<boolean>,
+    errorMessage: string,
+    successMessage: string
+  ) => {
+    if (!value) {
+      setMessage('');
+      setIsChecked(false);
+      return;
+    }
+
+    const exists = await checkFunc(value);
+    if (exists) {
+      setMessage(errorMessage);
+      setIsChecked(false);
+    } else {
+      setMessage(successMessage);
+      setIsChecked(true);
+    }
+  };
+
+  return { message, isChecked, checkDuplicate, setMessage, setIsChecked };
+};

--- a/src/hooks/useHashtagManage.ts
+++ b/src/hooks/useHashtagManage.ts
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import useToast from '@/hooks/useToast';
+
+export const useHashtagManage = () => {
+  const [hashtags, setHashtags] = useState<string[]>([]);
+  const [hashtag, setHashtag] = useState<string>('');
+  const { toastTrigger } = useToast();
+
+  const addHashtag = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+
+      const invalidString = /[\s!@#$%^&*(),.?":{}|<>]/;
+      if (invalidString.test(hashtag)) {
+        toastTrigger(
+          '해시태그에 공백이나 특수문자를 사용할 수 없습니다.',
+          'fail'
+        );
+        return;
+      }
+
+      if (hashtags.length >= 10) {
+        toastTrigger('해시태그는 최대 10개 제한입니다.', 'fail');
+        return;
+      }
+
+      const formattedHashtag = hashtag.startsWith('#')
+        ? hashtag
+        : `#${hashtag}`;
+
+      if (hashtag && hashtags.includes(formattedHashtag)) {
+        toastTrigger('이미 있는 해시태그입니다.', 'fail');
+        return;
+      }
+
+      if (hashtag) {
+        setHashtags((prev) => [...prev, formattedHashtag]);
+        setHashtag('');
+      }
+    }
+  };
+
+  const removeHashtag = (label: string) => {
+    setHashtags((prevHashtags) => prevHashtags.filter((tag) => tag !== label));
+  };
+
+  return {
+    hashtags,
+    hashtag,
+    setHashtag,
+    setHashtags,
+    addHashtag,
+    removeHashtag,
+  };
+};

--- a/src/pages/profile/ProfileUpdate.tsx
+++ b/src/pages/profile/ProfileUpdate.tsx
@@ -1,3 +1,132 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
+import { Camera } from 'lucide-react';
+import Button from '@/components/Button';
+import InputBox from '@/components/InputBox';
+import Profile from '@/components/Profile';
+import colors from '@/constants/colors';
+import { fontSize, fontWeight } from '@/constants/font';
+import { useAuthStore } from '@/stores/useAuthStore';
 
-export const ProfileUpdate = () => <div>UpdateProfile 프로필 수정 페이지</div>;
+export const ProfileUpdate = () => {
+  const { profileImage, channelName } = useAuthStore();
+  const [hashtag, setHashtag] = useState<string>('');
+
+  return (
+    <div css={containerStyle}>
+      <div css={profileContainerStyle}>
+        <div css={profileStyle}>
+          <Profile src={profileImage} alt='프로필 이미지' size='xl' />
+          <div css={cameraIconStyle}>
+            <Camera color={colors.white} size={24} />
+          </div>
+        </div>
+        <span css={profileNameStyle}>{channelName}</span>
+      </div>
+      <form css={formContainerStyle}>
+        <div css={duplicateStyle}>
+          <InputBox
+            label='채널 이름'
+            placeholder='채널 이름을 입력해주세요'
+            value={channelName}
+            onChange={() => {}}
+            width='315px'
+          />
+          <div style={{ marginLeft: `5px` }}>
+            <Button
+              label='중복검사'
+              color='gray'
+              onClick={() => {}}
+              size='lg'
+            />
+          </div>
+        </div>
+        <InputBox
+          label='해시태그 (최대 10개)'
+          placeholder='#'
+          value={hashtag}
+          onChange={() => {}}
+          width='315px'
+        />
+        <Button
+          label='프로필 저장'
+          onClick={() => {}}
+          type='submit'
+          size='lg'
+          fullWidth={true}
+        />
+      </form>
+    </div>
+  );
+};
+
+const containerStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const profileContainerStyle = css`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 20px 0;
+  padding-bottom: 20px;
+  border-bottom: 1px solid ${colors.gray02};
+`;
+
+const profileStyle = css`
+  position: relative;
+  width: 120px;
+  height: 120px;
+  cursor: pointer;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: ${colors.black};
+    opacity: 0.3;
+    border-radius: 50%;
+  }
+
+  &:hover {
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: ${colors.black};
+      opacity: 0.5;
+      border-radius: 50%;
+    }
+  }
+`;
+
+const cameraIconStyle = css`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+const profileNameStyle = css`
+  margin: 6px 0;
+  font-size: ${fontSize.xl};
+  color: ${colors.black};
+`;
+
+const duplicateStyle = css`
+  display: flex;
+  align-items: center;
+`;
+
+const formContainerStyle = css``;

--- a/src/pages/profile/ProfileUpdate.tsx
+++ b/src/pages/profile/ProfileUpdate.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
-import { doc, setDoc } from 'firebase/firestore';
+import { doc, setDoc, getDoc } from 'firebase/firestore';
 import { Camera } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -111,9 +111,19 @@ export const ProfileUpdate = () => {
       }
     }
 
-    navigate(ROUTES.PROFILE(userId));
-    window.location.reload();
+    const userDocRef = doc(db, 'users', userId);
+    const userSnapshot = await getDoc(userDocRef);
+
+    if (userSnapshot.exists()) {
+      const updatedData = userSnapshot.data();
+      useAuthStore.setState({
+        profileImage: updatedData.profileImg || previewUrl,
+        channelName: updatedData.channelName || newChannelName,
+      });
+    }
+
     toastTrigger('프로필 수정이 완료되었습니다.', 'success');
+    navigate(ROUTES.PROFILE(userId));
   };
 
   const validateChannelName = (value: string) => {

--- a/src/utils/checkDuplicate.ts
+++ b/src/utils/checkDuplicate.ts
@@ -1,0 +1,34 @@
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  getDoc,
+} from 'firebase/firestore';
+import { db } from '@/firebase/firbaseConfig';
+
+export const checkChannelNameExists = async (
+  channelName: string
+): Promise<boolean> => {
+  const q = query(
+    collection(db, 'users'),
+    where('channelName', '==', channelName)
+  );
+  try {
+    const querySnapshot = await getDocs(q);
+    return !querySnapshot.empty;
+  } catch (error) {
+    throw new Error('채널 이름 중복 체크에 실패했습니다.');
+  }
+};
+
+export const checkIdExists = async (id: string): Promise<boolean> => {
+  try {
+    const docRef = doc(db, 'users', id);
+    const docSnap = await getDoc(docRef);
+    return docSnap.exists();
+  } catch (error) {
+    throw new Error('아이디 중복 체크에 실패했습니다.');
+  }
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

프로필 수정 페이지 UI 퍼블리싱 & 기능구현

## 📋 작업 내용

- 프로필 수정 페이지 UI 퍼블리싱
- 프로필 사진 업로드
- 채널 이름 중복체크
- 해시태그 설정
- 뒤로가기 버튼 -> 모달
- 프로필 수정 완료 토스트

## 🔧 변경 사항

위와 같습니다

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/86448f88-27d5-45ed-bfd6-8ea5f5cbd943

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
