### PR TITLE
[feature] 검색 결과 페이지 태그 검색 기능 추가 구현

### DIFF
--- a/src/api/searchPlaylists.ts
+++ b/src/api/searchPlaylists.ts
@@ -50,9 +50,17 @@ const fetchPlaylists = async (
     })
   );
 
-  const filteredData = allPlaylists.filter((playlist) =>
-    playlist.title.toLowerCase().includes(keyword.toLowerCase())
-  );
+  let filteredData;
+
+  if (keyword.startsWith('#')) {
+    filteredData = allPlaylists.filter((playlist) =>
+      playlist.tags?.includes(keyword)
+    );
+  } else {
+    filteredData = allPlaylists.filter((playlist) =>
+      playlist.title.toLowerCase().includes(keyword.toLowerCase())
+    );
+  }
 
   return { filteredData, lastVisible };
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

검색 결과 페이지 태그 검색 기능 추가 구현

## 📋 작업 내용

- '#'을 붙여서 검색할 경우 플레이리스트의 해시태그 대상으로 검색할 수 있는 기능을 구현했습니다.

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

![ex](https://github.com/user-attachments/assets/f4ff1411-dc41-443d-9166-3fc76e275d75)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
