### PR TITLE
[bug] 프로필 수정 채널이름 중복 검사 문제 해결

### DIFF
--- a/src/pages/profile/ProfileUpdate.tsx
+++ b/src/pages/profile/ProfileUpdate.tsx
@@ -76,9 +76,9 @@ export const ProfileUpdate = () => {
   const onChannelNameChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
-    const newValue = e.target.value;
-    setNewChannelName(newValue);
-    checkChannelNameDuplicate(newValue, () => Promise.resolve(false), '', '');
+    setNewChannelName(e.target.value);
+    setIsChannelNameChecked(false);
+    setChannelNameCheckMessage('');
   };
 
   const onImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

프로필 수정 채널이름 중복 검사 문제 해결

## 📋 작업 내용

- 채널이름을 수정하고 중복검사를 하지 않아도 프로필 수정이 됨(중복 채널 이름 발생) 
- 중복검사 여부 초기화하는 부분 수정

## 🔧 변경 사항

위와 같습니다


